### PR TITLE
feat: add location autocomplete and geocoding service (#15)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
 import { FilesModule } from './modules/files/files.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { InvitationsModule } from './modules/invitations/invitations.module';
+import { LocationsModule } from './modules/locations/locations.module';
 
 @Module({
   imports: [
@@ -62,6 +63,7 @@ import { InvitationsModule } from './modules/invitations/invitations.module';
     FilesModule,
     AdminModule,
     InvitationsModule,
+    LocationsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/modules/locations/dto/index.ts
+++ b/src/modules/locations/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './location.dto';

--- a/src/modules/locations/dto/location.dto.ts
+++ b/src/modules/locations/dto/location.dto.ts
@@ -1,0 +1,67 @@
+import { IsString, IsOptional, IsNumber, Min, Max } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class LocationSearchDto {
+  @ApiProperty({ example: 'Barcelona', description: 'Search query for location' })
+  @IsString()
+  query: string;
+
+  @ApiPropertyOptional({ example: 5, description: 'Maximum number of results' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(20)
+  limit?: number;
+
+  @ApiPropertyOptional({ example: 'es', description: 'Country code to filter results' })
+  @IsOptional()
+  @IsString()
+  countryCode?: string;
+}
+
+export class LocationResultDto {
+  @ApiProperty({ example: 'Barcelona, Catalonia, Spain' })
+  displayName: string;
+
+  @ApiProperty({ example: 'Barcelona' })
+  city: string;
+
+  @ApiProperty({ example: 'Catalonia' })
+  region?: string;
+
+  @ApiProperty({ example: 'Spain' })
+  country: string;
+
+  @ApiProperty({ example: 'ES' })
+  countryCode: string;
+
+  @ApiProperty({ example: 41.3851 })
+  latitude: number;
+
+  @ApiProperty({ example: 2.1734 })
+  longitude: number;
+
+  @ApiPropertyOptional({ example: '08001' })
+  postalCode?: string;
+
+  @ApiPropertyOptional({ example: 'Carrer de Balmes, 100' })
+  address?: string;
+}
+
+export class ReverseGeocodeDto {
+  @ApiProperty({ example: 41.3851, description: 'Latitude coordinate' })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  latitude: number;
+
+  @ApiProperty({ example: 2.1734, description: 'Longitude coordinate' })
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  longitude: number;
+}

--- a/src/modules/locations/index.ts
+++ b/src/modules/locations/index.ts
@@ -1,0 +1,4 @@
+export * from './locations.module';
+export * from './locations.service';
+export * from './locations.controller';
+export * from './dto';

--- a/src/modules/locations/locations.controller.ts
+++ b/src/modules/locations/locations.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { LocationsService } from './locations.service';
+import {
+  LocationSearchDto,
+  LocationResultDto,
+  ReverseGeocodeDto,
+} from './dto';
+import { JwtAuthGuard } from '../auth/guards';
+import { Public } from '../../common/decorators';
+
+@ApiTags('Locations')
+@Controller('locations')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class LocationsController {
+  constructor(private readonly locationsService: LocationsService) {}
+
+  @Get('search')
+  @Public()
+  @ApiOperation({
+    summary: 'Search locations by query',
+    description: 'Search for locations using geocoding. Returns coordinates and location details.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of matching locations',
+    type: [LocationResultDto],
+  })
+  async searchLocations(
+    @Query() dto: LocationSearchDto,
+  ): Promise<LocationResultDto[]> {
+    return this.locationsService.searchLocations(dto);
+  }
+
+  @Get('autocomplete')
+  @Public()
+  @ApiOperation({
+    summary: 'Get location autocomplete suggestions',
+    description: 'Get autocomplete suggestions for location input. Minimum 2 characters required.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of autocomplete suggestions',
+    type: [LocationResultDto],
+  })
+  async getAutocomplete(
+    @Query('query') query: string,
+    @Query('countryCode') countryCode?: string,
+  ): Promise<LocationResultDto[]> {
+    return this.locationsService.getAutocompleteSuggestions(query, countryCode);
+  }
+
+  @Get('reverse')
+  @Public()
+  @ApiOperation({
+    summary: 'Reverse geocode coordinates',
+    description: 'Get location details from latitude/longitude coordinates.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Location details',
+    type: LocationResultDto,
+  })
+  async reverseGeocode(
+    @Query() dto: ReverseGeocodeDto,
+  ): Promise<LocationResultDto | null> {
+    return this.locationsService.reverseGeocode(dto);
+  }
+}

--- a/src/modules/locations/locations.module.ts
+++ b/src/modules/locations/locations.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LocationsService } from './locations.service';
+import { LocationsController } from './locations.controller';
+
+@Module({
+  controllers: [LocationsController],
+  providers: [LocationsService],
+  exports: [LocationsService],
+})
+export class LocationsModule {}

--- a/src/modules/locations/locations.service.ts
+++ b/src/modules/locations/locations.service.ts
@@ -1,0 +1,152 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  LocationSearchDto,
+  LocationResultDto,
+  ReverseGeocodeDto,
+} from './dto';
+
+@Injectable()
+export class LocationsService {
+  private readonly logger = new Logger(LocationsService.name);
+  private readonly nominatimBaseUrl = 'https://nominatim.openstreetmap.org';
+
+  constructor(private configService: ConfigService) {}
+
+  /**
+   * Search for locations using Nominatim (OpenStreetMap) geocoding service
+   * This is a free service, but has rate limiting (1 request per second)
+   * For production, consider using Google Places API or similar paid service
+   */
+  async searchLocations(dto: LocationSearchDto): Promise<LocationResultDto[]> {
+    const { query, limit = 5, countryCode } = dto;
+
+    try {
+      const params = new URLSearchParams({
+        q: query,
+        format: 'json',
+        addressdetails: '1',
+        limit: limit.toString(),
+        'accept-language': 'en',
+      });
+
+      if (countryCode) {
+        params.append('countrycodes', countryCode);
+      }
+
+      const response = await fetch(
+        `${this.nominatimBaseUrl}/search?${params.toString()}`,
+        {
+          headers: {
+            'User-Agent': 'FootballTournamentPlatform/1.0',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        this.logger.warn(`Nominatim API error: ${response.status}`);
+        return [];
+      }
+
+      const results = await response.json();
+
+      return results.map((result: any) => this.mapNominatimResult(result));
+    } catch (error) {
+      this.logger.error('Error searching locations:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Reverse geocode coordinates to get location details
+   */
+  async reverseGeocode(dto: ReverseGeocodeDto): Promise<LocationResultDto | null> {
+    const { latitude, longitude } = dto;
+
+    try {
+      const params = new URLSearchParams({
+        lat: latitude.toString(),
+        lon: longitude.toString(),
+        format: 'json',
+        addressdetails: '1',
+        'accept-language': 'en',
+      });
+
+      const response = await fetch(
+        `${this.nominatimBaseUrl}/reverse?${params.toString()}`,
+        {
+          headers: {
+            'User-Agent': 'FootballTournamentPlatform/1.0',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        this.logger.warn(`Nominatim reverse geocode error: ${response.status}`);
+        return null;
+      }
+
+      const result = await response.json();
+
+      if (result.error) {
+        return null;
+      }
+
+      return this.mapNominatimResult(result);
+    } catch (error) {
+      this.logger.error('Error reverse geocoding:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Get autocomplete suggestions for location input
+   * This method adds debouncing on the client side
+   */
+  async getAutocompleteSuggestions(
+    query: string,
+    countryCode?: string,
+  ): Promise<LocationResultDto[]> {
+    if (!query || query.length < 2) {
+      return [];
+    }
+
+    return this.searchLocations({
+      query,
+      limit: 10,
+      countryCode,
+    });
+  }
+
+  private mapNominatimResult(result: any): LocationResultDto {
+    const address = result.address || {};
+
+    return {
+      displayName: result.display_name,
+      city:
+        address.city ||
+        address.town ||
+        address.village ||
+        address.municipality ||
+        address.county ||
+        '',
+      region: address.state || address.region || '',
+      country: address.country || '',
+      countryCode: (address.country_code || '').toUpperCase(),
+      latitude: parseFloat(result.lat),
+      longitude: parseFloat(result.lon),
+      postalCode: address.postcode || undefined,
+      address: this.buildAddressString(address),
+    };
+  }
+
+  private buildAddressString(address: any): string | undefined {
+    const parts = [
+      address.house_number,
+      address.road,
+      address.suburb,
+    ].filter(Boolean);
+
+    return parts.length > 0 ? parts.join(', ') : undefined;
+  }
+}


### PR DESCRIPTION
- Create new locations module with LocationsService and LocationsController
- Add GET /locations/search endpoint for location search
- Add GET /locations/autocomplete endpoint for autocomplete suggestions
- Add GET /locations/reverse endpoint for reverse geocoding
- Uses OpenStreetMap Nominatim API (free, rate-limited)
- Returns city, country, coordinates, and address details

Tournament and club location fields can now use autocomplete.