### PR TITLE
fix(tournaments): implement date-only handling for tournament dates (…

### DIFF
--- a/src/common/transformers/date.transformer.spec.ts
+++ b/src/common/transformers/date.transformer.spec.ts
@@ -1,0 +1,55 @@
+import { DateOnlyTransformer } from './date.transformer';
+
+describe('DateOnlyTransformer', () => {
+  let transformer: DateOnlyTransformer;
+
+  beforeEach(() => {
+    transformer = new DateOnlyTransformer();
+  });
+
+  describe('to (write to database)', () => {
+    it('should convert string to Date', () => {
+      const result = transformer.to('2025-07-01');
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.toISOString().split('T')[0]).toBe('2025-07-01');
+    });
+
+    it('should handle Date object', () => {
+      const date = new Date('2025-07-01');
+      const result = transformer.to(date);
+      expect(result).toBe(date);
+    });
+
+    it('should handle null', () => {
+      expect(transformer.to(null)).toBeNull();
+    });
+
+    it('should handle undefined', () => {
+      expect(transformer.to(undefined)).toBeNull();
+    });
+  });
+
+  describe('from (read from database)', () => {
+    it('should convert Date to YYYY-MM-DD string', () => {
+      const date = new Date('2025-07-01T10:30:00Z');
+      const result = transformer.from(date);
+      expect(result).toBe('2025-07-01');
+    });
+
+    it('should handle null', () => {
+      expect(transformer.from(null)).toBeNull();
+    });
+
+    it('should handle undefined', () => {
+      expect(transformer.from(undefined)).toBeNull();
+    });
+
+    it('should strip time component', () => {
+      const date = new Date('2025-12-25T23:59:59.999Z');
+      const result = transformer.from(date);
+      expect(result).toBe('2025-12-25');
+      expect(result).not.toContain('T');
+      expect(result).not.toContain(':');
+    });
+  });
+});

--- a/src/common/transformers/date.transformer.ts
+++ b/src/common/transformers/date.transformer.ts
@@ -1,0 +1,38 @@
+import { ValueTransformer } from 'typeorm';
+
+/**
+ * Transformer for date-only columns (no time component)
+ * Ensures dates are stored and returned in YYYY-MM-DD format
+ */
+export class DateOnlyTransformer implements ValueTransformer {
+  /**
+   * Transforms the value when writing to the database
+   * @param value - Date object or string from the entity
+   * @returns Date object for the database
+   */
+  to(value: Date | string | null | undefined): Date | null {
+    if (!value) return null;
+    
+    if (typeof value === 'string') {
+      // Parse YYYY-MM-DD string to Date
+      return new Date(value);
+    }
+    
+    return value;
+  }
+
+  /**
+   * Transforms the value when reading from the database
+   * @param value - Date object from the database
+   * @returns YYYY-MM-DD string for the API response
+   */
+  from(value: Date | null | undefined): string | null {
+    if (!value) return null;
+    
+    // Ensure we have a Date object
+    const date = value instanceof Date ? value : new Date(value);
+    
+    // Return YYYY-MM-DD format (ISO date string without time)
+    return date.toISOString().split('T')[0];
+  }
+}

--- a/src/common/transformers/index.ts
+++ b/src/common/transformers/index.ts
@@ -1,0 +1,1 @@
+export * from './date.transformer';

--- a/src/modules/tournaments/dto/tournament.dto.ts
+++ b/src/modules/tournaments/dto/tournament.dto.ts
@@ -14,6 +14,7 @@ import {
   Min,
   Max,
   IsObject,
+  Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -114,14 +115,16 @@ export class CreateAgeGroupDto {
   @Max(20)
   guaranteedMatches?: number;
 
-  @ApiPropertyOptional({ example: '2025-07-01' })
+  @ApiPropertyOptional({ example: '2025-07-01', description: 'Age group start date (YYYY-MM-DD format)' })
   @IsOptional()
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'startDate must be in YYYY-MM-DD format' })
   startDate?: string;
 
-  @ApiPropertyOptional({ example: '2025-07-02' })
+  @ApiPropertyOptional({ example: '2025-07-02', description: 'Age group end date (YYYY-MM-DD format)' })
   @IsOptional()
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'endDate must be in YYYY-MM-DD format' })
   endDate?: string;
 
   @ApiPropertyOptional({ description: 'Location ID for this age group' })
@@ -203,14 +206,16 @@ export class UpdateAgeGroupDto {
   @Max(128)
   maxTeams?: number;
 
-  @ApiPropertyOptional({ example: '2025-07-01' })
+  @ApiPropertyOptional({ example: '2025-07-01', description: 'Age group start date (YYYY-MM-DD format)' })
   @IsOptional()
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'startDate must be in YYYY-MM-DD format' })
   startDate?: string;
 
-  @ApiPropertyOptional({ example: '2025-07-02' })
+  @ApiPropertyOptional({ example: '2025-07-02', description: 'Age group end date (YYYY-MM-DD format)' })
   @IsOptional()
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'endDate must be in YYYY-MM-DD format' })
   endDate?: string;
 
   @ApiPropertyOptional({ description: 'Location ID for this age group' })
@@ -375,12 +380,14 @@ export class CreateTournamentDto {
   @MaxLength(5000)
   description?: string;
 
-  @ApiProperty({ example: '2025-07-01' })
+  @ApiProperty({ example: '2025-07-01', description: 'Tournament start date (YYYY-MM-DD format, date only)' })
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'startDate must be in YYYY-MM-DD format' })
   startDate: string;
 
-  @ApiProperty({ example: '2025-07-05' })
+  @ApiProperty({ example: '2025-07-05', description: 'Tournament end date (YYYY-MM-DD format, date only)' })
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'endDate must be in YYYY-MM-DD format' })
   endDate: string;
 
   @ApiProperty({ example: 'Barcelona, Spain' })
@@ -628,14 +635,16 @@ export class UpdateTournamentDto {
   @MaxLength(5000)
   description?: string;
 
-  @ApiPropertyOptional({ example: '2025-07-01' })
+  @ApiPropertyOptional({ example: '2025-07-01', description: 'Tournament start date (YYYY-MM-DD format)' })
   @IsOptional()
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'startDate must be in YYYY-MM-DD format' })
   startDate?: string;
 
-  @ApiPropertyOptional({ example: '2025-07-05' })
+  @ApiPropertyOptional({ example: '2025-07-05', description: 'Tournament end date (YYYY-MM-DD format)' })
   @IsOptional()
   @IsDateString()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'endDate must be in YYYY-MM-DD format' })
   endDate?: string;
 
   @ApiPropertyOptional({ example: 'Barcelona, Spain' })

--- a/src/modules/tournaments/entities/tournament-age-group.entity.ts
+++ b/src/modules/tournaments/entities/tournament-age-group.entity.ts
@@ -8,6 +8,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { Tournament } from './tournament.entity';
+import { DateOnlyTransformer } from '../../../common/transformers';
 
 // Game systems available per age category
 export type GameSystem =
@@ -71,11 +72,11 @@ export class TournamentAgeGroup {
   guaranteedMatches?: number;
 
   // Independent date range for this age group
-  @Column({ name: 'start_date', type: 'date' })
-  startDate: Date;
+  @Column({ name: 'start_date', type: 'date', transformer: new DateOnlyTransformer() })
+  startDate: Date | string;
 
-  @Column({ name: 'end_date', type: 'date' })
-  endDate: Date;
+  @Column({ name: 'end_date', type: 'date', transformer: new DateOnlyTransformer() })
+  endDate: Date | string;
 
   // Optional: assigned location ID (references TournamentLocation)
   @Column({ name: 'location_id', nullable: true })

--- a/src/modules/tournaments/entities/tournament.entity.ts
+++ b/src/modules/tournaments/entities/tournament.entity.ts
@@ -15,6 +15,7 @@ import {
   Currency,
   AgeCategory,
 } from '../../../common/enums';
+import { DateOnlyTransformer } from '../../../common/transformers';
 import { User } from '../../users/entities/user.entity';
 import { Registration } from '../../registrations/entities/registration.entity';
 import { Group } from '../../groups/entities/group.entity';
@@ -51,11 +52,11 @@ export class Tournament {
   status: TournamentStatus;
 
   @Index()
-  @Column({ name: 'start_date', type: 'date' })
-  startDate: Date;
+  @Column({ name: 'start_date', type: 'date', transformer: new DateOnlyTransformer() })
+  startDate: Date | string;
 
-  @Column({ name: 'end_date', type: 'date' })
-  endDate: Date;
+  @Column({ name: 'end_date', type: 'date', transformer: new DateOnlyTransformer() })
+  endDate: Date | string;
 
   @Column()
   location: string;
@@ -92,7 +93,6 @@ export class Tournament {
   @Column({ name: 'guaranteed_matches', nullable: true })
   guaranteedMatches: number;
 
-  @Column({ name: 'max_teams' })
   @Column({ name: 'max_teams', nullable: true })
   maxTeams: number;
 
@@ -133,14 +133,14 @@ export class Tournament {
   @Column({ type: 'json', nullable: true })
   tags?: string[];
 
-  @Column({ name: 'registration_deadline', type: 'date', nullable: true })
-  registrationDeadline?: Date;
+  @Column({ name: 'registration_deadline', type: 'date', nullable: true, transformer: new DateOnlyTransformer() })
+  registrationDeadline?: Date | string;
 
-  @Column({ name: 'registration_start_date', type: 'date', nullable: true })
-  registrationStartDate?: Date;
+  @Column({ name: 'registration_start_date', type: 'date', nullable: true, transformer: new DateOnlyTransformer() })
+  registrationStartDate?: Date | string;
 
-  @Column({ name: 'registration_end_date', type: 'date', nullable: true })
-  registrationEndDate?: Date;
+  @Column({ name: 'registration_end_date', type: 'date', nullable: true, transformer: new DateOnlyTransformer() })
+  registrationEndDate?: Date | string;
 
   @Column({ name: 'contact_email', nullable: true })
   contactEmail?: string;


### PR DESCRIPTION
…Issue #43)

- Add DateOnlyTransformer to ensure dates are stored and returned in YYYY-MM-DD format
- Update Tournament and TournamentAgeGroup entities to use the transformer
- Add validation for YYYY-MM-DD format in DTOs using @Matches decorator
- Remove duplicate max_teams column definition in Tournament entity
- Update service layer to work with date strings instead of Date objects
- Add comprehensive unit tests for DateOnlyTransformer

This ensures:
- API responses return dates without time component
- Frontend receives dates in YYYY-MM-DD format
- Database stores dates correctly as DATE type
- Validation rejects datetime strings

Related to frontend issue #61