### PR TITLE
feat(#87): Teams and Players entities and endpoints

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npm uninstall:*)",
-      "Bash(npm install:*)",
-      "Bash(pnpm install:*)"
-    ]
-  }
-}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Copilot instructions for sport-tournaments-backend
+
+## Architecture & data flow
+- NestJS 11 API with global prefix + URI versioning: /api/v1/... (see src/main.ts).
+- Request flow: ValidationPipe (whitelist + forbidNonWhitelisted) → guards → controllers → services → repositories → TransformInterceptor response envelope.
+- Response envelope:
+  - Success: { success: true, data: ... } (common/interceptors/transform.interceptor.ts).
+  - Errors: { success: false, error: { code, message, details? } } (common/filters/all-exceptions.filter.ts).
+- Feature modules live in src/modules/* and follow module/controller/service/dto/entities pattern (see docs/ARCHITECTURE.md).
+- Swagger is enabled only in development at /api/docs and /api/swagger-json (src/main.ts).
+- Health check endpoint: GET /health (src/main.ts).
+
+## Database & config
+- PostgreSQL only. DATABASE_URL is required and must start with postgres:// or postgresql:// (src/config/database.config.ts).
+- TypeORM auto-loads entities and synchronizes in dev; config is driven via src/config/configuration.ts.
+- ConfigModule loads .env.local then .env (src/app.module.ts).
+- CORS uses CORS_ORIGINS and allows local network origins in dev; credentials are enabled (src/main.ts).
+
+## External integrations
+- Stripe payments, S3-compatible storage (MinIO in docker-compose), SendGrid email; see docker-compose.yml env vars.
+- Throttler defaults to 100 req/min (src/app.module.ts).
+
+## Developer workflows
+- pnpm start:dev (dev server)
+- pnpm test:e2e (E2E)
+- pnpm seed (seed data)
+- Docker stack: postgres, redis, minio via docker-compose.yml
+
+## Conventions & examples
+- DTO validation is mandatory; unknown fields are rejected.
+- Prefer returning domain data and let TransformInterceptor wrap it.
+- Use standardized error codes from AllExceptionsFilter when throwing HTTP exceptions.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { InvitationsModule } from './modules/invitations/invitations.module';
 import { LocationsModule } from './modules/locations/locations.module';
 import { MailModule } from './modules/mail/mail.module';
 import { TeamsModule } from './modules/teams/teams.module';
+import { PlayersModule } from './modules/players/players.module';
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { TeamsModule } from './modules/teams/teams.module';
     InvitationsModule,
     LocationsModule,
     TeamsModule,
+    PlayersModule,
   ],
   controllers: [],
   providers: [],

--- a/src/modules/players/dto/player.dto.ts
+++ b/src/modules/players/dto/player.dto.ts
@@ -1,0 +1,104 @@
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { PaginationDto } from '../../../common/dto';
+
+export class CreatePlayerDto {
+  @ApiProperty({ example: 'Alex', description: 'Player first name' })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(80)
+  firstname: string;
+
+  @ApiProperty({ example: 'Popescu', description: 'Player last name' })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(80)
+  lastname: string;
+
+  @ApiProperty({ example: '2010-04-15', description: 'Player birth date' })
+  @IsDateString()
+  dateOfBirth: string;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Optional list of team IDs to associate player with',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  teamIds?: string[];
+}
+
+export class UpdatePlayerDto {
+  @ApiPropertyOptional({ example: 'Alex', description: 'Player first name' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(80)
+  firstname?: string;
+
+  @ApiPropertyOptional({ example: 'Popescu', description: 'Player last name' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(80)
+  lastname?: string;
+
+  @ApiPropertyOptional({ example: '2010-04-15', description: 'Player birth date' })
+  @IsOptional()
+  @IsDateString()
+  dateOfBirth?: string;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Replace player teams with the provided team IDs',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  teamIds?: string[];
+}
+
+export class PlayerFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by team ID' })
+  @IsOptional()
+  @IsUUID()
+  teamId?: string;
+
+  @ApiPropertyOptional({ description: 'Search by first/last name' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}
+
+export class PlayerSearchDto {
+  @ApiPropertyOptional({ description: 'Search text query' })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by team ID' })
+  @IsOptional()
+  @IsUUID()
+  teamId?: string;
+
+  @ApiPropertyOptional({ description: 'Maximum results', default: 10, minimum: 1, maximum: 50 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number = 10;
+}

--- a/src/modules/players/entities/index.ts
+++ b/src/modules/players/entities/index.ts
@@ -1,0 +1,1 @@
+export { Player } from './player.entity';

--- a/src/modules/players/entities/player.entity.ts
+++ b/src/modules/players/entities/player.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToMany,
+  Index,
+} from 'typeorm';
+import { Team } from '../../teams/entities/team.entity';
+
+@Entity('players')
+@Index(['firstname', 'lastname'])
+export class Player {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  firstname: string;
+
+  @Column()
+  lastname: string;
+
+  @Column({ name: 'date_of_birth', type: 'date' })
+  dateOfBirth: string;
+
+  @ManyToMany(() => Team, (team) => team.players)
+  teams: Team[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/modules/players/players.controller.ts
+++ b/src/modules/players/players.controller.ts
@@ -1,0 +1,92 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { PlayersService } from './players.service';
+import { JwtAuthGuard, RolesGuard } from '../auth/guards';
+import { CurrentUser, Roles } from '../../common/decorators';
+import { UserRole } from '../../common/enums';
+import { JwtPayload } from '../../common/interfaces';
+import {
+  CreatePlayerDto,
+  PlayerFilterDto,
+  PlayerSearchDto,
+  UpdatePlayerDto,
+} from './dto/player.dto';
+
+@ApiTags('Players')
+@Controller('players')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@ApiBearerAuth()
+export class PlayersController {
+  constructor(private readonly playersService: PlayersService) {}
+
+  @Get()
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get players with optional filters' })
+  @ApiResponse({ status: 200, description: 'List of players' })
+  findAll(@CurrentUser() user: JwtPayload, @Query() filters: PlayerFilterDto) {
+    return this.playersService.findAll(filters, user);
+  }
+
+  @Get('search')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Search players by text query' })
+  @ApiResponse({ status: 200, description: 'Search results' })
+  search(@CurrentUser() user: JwtPayload, @Query() query: PlayerSearchDto) {
+    return this.playersService.search(query.q || '', user, query.teamId, query.limit || 10);
+  }
+
+  @Get('autocomplete')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Autocomplete players by text query' })
+  @ApiResponse({ status: 200, description: 'Autocomplete suggestions' })
+  autocomplete(@CurrentUser() user: JwtPayload, @Query() query: PlayerSearchDto) {
+    return this.playersService.autocomplete(query.q || '', user, query.teamId, query.limit || 10);
+  }
+
+  @Post()
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Create a player' })
+  @ApiResponse({ status: 201, description: 'Player created successfully' })
+  create(@CurrentUser() user: JwtPayload, @Body() createPlayerDto: CreatePlayerDto) {
+    return this.playersService.create(user, createPlayerDto);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get player by ID' })
+  @ApiResponse({ status: 200, description: 'Player details' })
+  findOne(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: JwtPayload) {
+    return this.playersService.findOne(id, user);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Update player' })
+  @ApiResponse({ status: 200, description: 'Player updated successfully' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() updatePlayerDto: UpdatePlayerDto,
+  ) {
+    return this.playersService.update(id, user, updatePlayerDto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Delete player' })
+  @ApiResponse({ status: 200, description: 'Player deleted successfully' })
+  remove(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: JwtPayload) {
+    return this.playersService.remove(id, user);
+  }
+}

--- a/src/modules/players/players.module.ts
+++ b/src/modules/players/players.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PlayersController } from './players.controller';
+import { PlayersService } from './players.service';
+import { Player } from './entities/player.entity';
+import { Team } from '../teams/entities/team.entity';
+import { Club } from '../clubs/entities/club.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Player, Team, Club])],
+  controllers: [PlayersController],
+  providers: [PlayersService],
+  exports: [PlayersService],
+})
+export class PlayersModule {}

--- a/src/modules/players/players.service.ts
+++ b/src/modules/players/players.service.ts
@@ -1,0 +1,220 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Player } from './entities/player.entity';
+import { Team } from '../teams/entities/team.entity';
+import { Club } from '../clubs/entities/club.entity';
+import {
+  CreatePlayerDto,
+  PlayerFilterDto,
+  UpdatePlayerDto,
+} from './dto/player.dto';
+import { JwtPayload } from '../../common/interfaces';
+import { UserRole } from '../../common/enums';
+
+@Injectable()
+export class PlayersService {
+  constructor(
+    @InjectRepository(Player)
+    private readonly playersRepository: Repository<Player>,
+    @InjectRepository(Team)
+    private readonly teamsRepository: Repository<Team>,
+    @InjectRepository(Club)
+    private readonly clubsRepository: Repository<Club>,
+  ) {}
+
+  private async resolveTeams(teamIds: string[], user: JwtPayload): Promise<Team[]> {
+    if (!teamIds?.length) {
+      return [];
+    }
+
+    const teams = await this.teamsRepository.find({
+      where: { id: In(teamIds) },
+      relations: ['club'],
+    });
+
+    if (teams.length !== teamIds.length) {
+      throw new NotFoundException('One or more teams were not found');
+    }
+
+    if (user.role !== UserRole.ADMIN) {
+      const unauthorized = teams.some((team) => team.club.organizerId !== user.sub);
+
+      if (unauthorized) {
+        throw new ForbiddenException('You can only manage players for your own clubs');
+      }
+    }
+
+    return teams;
+  }
+
+  private async findByIdOrFail(id: string): Promise<Player> {
+    const player = await this.playersRepository.findOne({
+      where: { id },
+      relations: ['teams', 'teams.club'],
+    });
+
+    if (!player) {
+      throw new NotFoundException(`Player with ID ${id} not found`);
+    }
+
+    return player;
+  }
+
+  private verifyPlayerAccess(player: Player, user: JwtPayload): void {
+    if (user.role === UserRole.ADMIN) {
+      return;
+    }
+
+    const canAccess = player.teams.some((team) => team.club.organizerId === user.sub);
+    if (!canAccess) {
+      throw new ForbiddenException('You can only manage players for your own clubs');
+    }
+  }
+
+  private createAccessScopedQuery(user: JwtPayload) {
+    const queryBuilder = this.playersRepository
+      .createQueryBuilder('player')
+      .leftJoinAndSelect('player.teams', 'team')
+      .leftJoinAndSelect('team.club', 'club');
+
+    if (user.role !== UserRole.ADMIN) {
+      queryBuilder.andWhere('club.organizerId = :organizerId', {
+        organizerId: user.sub,
+      });
+    }
+
+    return queryBuilder;
+  }
+
+  async findAll(filters: PlayerFilterDto, user: JwtPayload): Promise<Player[]> {
+    const { page = 1, pageSize = 20 } = filters;
+    const skip = (page - 1) * pageSize;
+
+    const queryBuilder = this.createAccessScopedQuery(user);
+
+    if (filters.teamId) {
+      queryBuilder.andWhere('team.id = :teamId', { teamId: filters.teamId });
+    }
+
+    if (filters.search) {
+      queryBuilder.andWhere(
+        '(LOWER(player.firstname) LIKE LOWER(:search) OR LOWER(player.lastname) LIKE LOWER(:search))',
+        { search: `%${filters.search}%` },
+      );
+    }
+
+    return queryBuilder
+      .orderBy('player.lastname', 'ASC')
+      .addOrderBy('player.firstname', 'ASC')
+      .skip(skip)
+      .take(pageSize)
+      .getMany();
+  }
+
+  async findOne(id: string, user: JwtPayload): Promise<Player> {
+    const player = await this.findByIdOrFail(id);
+    this.verifyPlayerAccess(player, user);
+    return player;
+  }
+
+  async create(user: JwtPayload, dto: CreatePlayerDto): Promise<Player> {
+    if (user.role !== UserRole.ADMIN && (!dto.teamIds || dto.teamIds.length === 0)) {
+      throw new BadRequestException('teamIds is required for non-admin users');
+    }
+
+    const teams = await this.resolveTeams(dto.teamIds || [], user);
+
+    const player = this.playersRepository.create({
+      firstname: dto.firstname,
+      lastname: dto.lastname,
+      dateOfBirth: dto.dateOfBirth,
+      teams,
+    });
+
+    return this.playersRepository.save(player);
+  }
+
+  async update(id: string, user: JwtPayload, dto: UpdatePlayerDto): Promise<Player> {
+    const player = await this.findByIdOrFail(id);
+    this.verifyPlayerAccess(player, user);
+
+    if (dto.firstname !== undefined) {
+      player.firstname = dto.firstname;
+    }
+
+    if (dto.lastname !== undefined) {
+      player.lastname = dto.lastname;
+    }
+
+    if (dto.dateOfBirth !== undefined) {
+      player.dateOfBirth = dto.dateOfBirth;
+    }
+
+    if (dto.teamIds !== undefined) {
+      if (user.role !== UserRole.ADMIN && dto.teamIds.length === 0) {
+        throw new BadRequestException('teamIds cannot be empty for non-admin users');
+      }
+
+      player.teams = await this.resolveTeams(dto.teamIds, user);
+    }
+
+    return this.playersRepository.save(player);
+  }
+
+  async remove(id: string, user: JwtPayload): Promise<void> {
+    const player = await this.findByIdOrFail(id);
+    this.verifyPlayerAccess(player, user);
+    await this.playersRepository.remove(player);
+  }
+
+  async search(
+    query: string,
+    user: JwtPayload,
+    teamId?: string,
+    limit: number = 10,
+  ): Promise<Player[]> {
+    if (!query?.trim()) {
+      return [];
+    }
+
+    const safeLimit = Math.min(Math.max(limit || 10, 1), 50);
+    const queryBuilder = this.createAccessScopedQuery(user);
+
+    if (teamId) {
+      queryBuilder.andWhere('team.id = :teamId', { teamId });
+    }
+
+    queryBuilder.andWhere(
+      '(LOWER(player.firstname) LIKE LOWER(:query) OR LOWER(player.lastname) LIKE LOWER(:query))',
+      { query: `%${query}%` },
+    );
+
+    return queryBuilder
+      .orderBy('player.lastname', 'ASC')
+      .addOrderBy('player.firstname', 'ASC')
+      .take(safeLimit)
+      .getMany();
+  }
+
+  async autocomplete(
+    query: string,
+    user: JwtPayload,
+    teamId?: string,
+    limit: number = 10,
+  ): Promise<Array<{ id: string; firstname: string; lastname: string; label: string }>> {
+    const players = await this.search(query, user, teamId, limit);
+
+    return players.map((player) => ({
+      id: player.id,
+      firstname: player.firstname,
+      lastname: player.lastname,
+      label: `${player.firstname} ${player.lastname}`,
+    }));
+  }
+}

--- a/src/modules/teams/dto/team.dto.ts
+++ b/src/modules/teams/dto/team.dto.ts
@@ -1,5 +1,17 @@
-import { IsString, MinLength, MaxLength, IsUUID } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsString,
+  MinLength,
+  MaxLength,
+  IsUUID,
+  IsOptional,
+  IsInt,
+  Min,
+  Max,
+  IsArray,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { PaginationDto } from '../../../common/dto';
 
 export class CreateTeamDto {
   @ApiProperty({ description: 'Club ID for the team' })
@@ -11,4 +23,89 @@ export class CreateTeamDto {
   @MinLength(2)
   @MaxLength(80)
   name: string;
+
+  @ApiProperty({ example: 'U17', description: 'Team age category' })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(40)
+  ageCategory: string;
+
+  @ApiProperty({ example: 2009, description: 'Team birth year' })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1900)
+  @Max(new Date().getFullYear() + 1)
+  birthyear: number;
+
+  @ApiProperty({ example: 'John Smith', description: 'Team coach name' })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(120)
+  coach: string;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Optional player IDs to assign to the team',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  playerIds?: string[];
+}
+
+export class UpdateTeamDto {
+  @ApiPropertyOptional({ description: 'Club ID for the team' })
+  @IsOptional()
+  @IsUUID()
+  clubId?: string;
+
+  @ApiPropertyOptional({ example: 'U17 A', description: 'Team name' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(80)
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'U17', description: 'Team age category' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(40)
+  ageCategory?: string;
+
+  @ApiPropertyOptional({ example: 2009, description: 'Team birth year' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1900)
+  @Max(new Date().getFullYear() + 1)
+  birthyear?: number;
+
+  @ApiPropertyOptional({ example: 'John Smith', description: 'Team coach name' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(120)
+  coach?: string;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Replace team players with the provided list of player IDs',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  playerIds?: string[];
+}
+
+export class TeamFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ description: 'Filter by club ID' })
+  @IsOptional()
+  @IsUUID()
+  clubId?: string;
+
+  @ApiPropertyOptional({ description: 'Search by team name, coach or age category' })
+  @IsOptional()
+  @IsString()
+  search?: string;
 }

--- a/src/modules/teams/entities/team.entity.ts
+++ b/src/modules/teams/entities/team.entity.ts
@@ -6,11 +6,14 @@ import {
   UpdateDateColumn,
   ManyToOne,
   OneToMany,
+  ManyToMany,
   Index,
   JoinColumn,
+  JoinTable,
 } from 'typeorm';
 import { Club } from '../../clubs/entities/club.entity';
 import { Registration } from '../../registrations/entities/registration.entity';
+import { Player } from '../../players/entities';
 
 @Entity('teams')
 @Index(['clubId', 'name'], { unique: true })
@@ -29,6 +32,15 @@ export class Team {
   @Column()
   name: string;
 
+  @Column({ name: 'age_category' })
+  ageCategory: string;
+
+  @Column({ type: 'int' })
+  birthyear: number;
+
+  @Column()
+  coach: string;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
@@ -37,4 +49,12 @@ export class Team {
 
   @OneToMany(() => Registration, (registration) => registration.team)
   registrations: Registration[];
+
+  @ManyToMany(() => Player, (player) => player.teams)
+  @JoinTable({
+    name: 'team_players',
+    joinColumn: { name: 'team_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'player_id', referencedColumnName: 'id' },
+  })
+  players: Player[];
 }

--- a/src/modules/teams/teams.controller.ts
+++ b/src/modules/teams/teams.controller.ts
@@ -2,6 +2,9 @@ import {
   Controller,
   Get,
   Post,
+  Patch,
+  Delete,
+  Param,
   Body,
   Query,
   UseGuards,
@@ -9,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { TeamsService } from './teams.service';
-import { CreateTeamDto } from './dto/team.dto';
+import { CreateTeamDto, TeamFilterDto, UpdateTeamDto } from './dto/team.dto';
 import { JwtAuthGuard, RolesGuard } from '../auth/guards';
 import { Roles, CurrentUser } from '../../common/decorators';
 import { UserRole } from '../../common/enums';
@@ -24,13 +27,26 @@ export class TeamsController {
 
   @Get()
   @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
-  @ApiOperation({ summary: 'Get teams by club ID' })
-  @ApiResponse({ status: 200, description: 'List of teams for club' })
-  findByClub(
+  @ApiOperation({ summary: 'Get teams with optional filters' })
+  @ApiResponse({ status: 200, description: 'List of teams' })
+  findAll(
     @CurrentUser() user: JwtPayload,
-    @Query('clubId', ParseUUIDPipe) clubId: string,
+    @Query() filters: TeamFilterDto,
   ) {
-    return this.teamsService.findByClub(clubId, user);
+    return this.teamsService.findAll(filters, user);
+  }
+
+  @Get('search')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Search teams by text query' })
+  @ApiResponse({ status: 200, description: 'Search results' })
+  search(
+    @CurrentUser() user: JwtPayload,
+    @Query('q') query: string,
+    @Query('clubId') clubId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.teamsService.search(query, user, clubId, Number(limit) || 10);
   }
 
   @Post()
@@ -42,5 +58,40 @@ export class TeamsController {
     @Body() createTeamDto: CreateTeamDto,
   ) {
     return this.teamsService.create(user, createTeamDto);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER, UserRole.ADMIN)
+  @ApiOperation({ summary: 'Get team by ID' })
+  @ApiResponse({ status: 200, description: 'Team details' })
+  @ApiResponse({ status: 404, description: 'Team not found' })
+  findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    return this.teamsService.findOne(id, user);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER)
+  @ApiOperation({ summary: 'Update team' })
+  @ApiResponse({ status: 200, description: 'Team updated successfully' })
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() updateTeamDto: UpdateTeamDto,
+  ) {
+    return this.teamsService.update(id, user, updateTeamDto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ORGANIZER, UserRole.PARTICIPANT, UserRole.USER)
+  @ApiOperation({ summary: 'Delete team' })
+  @ApiResponse({ status: 200, description: 'Team deleted successfully' })
+  remove(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: JwtPayload,
+  ) {
+    return this.teamsService.remove(id, user);
   }
 }

--- a/src/modules/teams/teams.module.ts
+++ b/src/modules/teams/teams.module.ts
@@ -4,9 +4,10 @@ import { TeamsController } from './teams.controller';
 import { TeamsService } from './teams.service';
 import { Team } from './entities/team.entity';
 import { Club } from '../clubs/entities/club.entity';
+import { Player } from '../players/entities/player.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Team, Club])],
+  imports: [TypeOrmModule.forFeature([Team, Club, Player])],
   controllers: [TeamsController],
   providers: [TeamsService],
   exports: [TeamsService],

--- a/src/modules/teams/teams.service.ts
+++ b/src/modules/teams/teams.service.ts
@@ -5,12 +5,13 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Not, Repository } from 'typeorm';
 import { Team } from './entities/team.entity';
 import { Club } from '../clubs/entities/club.entity';
-import { CreateTeamDto } from './dto/team.dto';
+import { CreateTeamDto, TeamFilterDto, UpdateTeamDto } from './dto/team.dto';
 import { JwtPayload } from '../../common/interfaces';
 import { UserRole } from '../../common/enums';
+import { Player } from '../players/entities';
 
 @Injectable()
 export class TeamsService {
@@ -19,6 +20,8 @@ export class TeamsService {
     private teamsRepository: Repository<Team>,
     @InjectRepository(Club)
     private clubsRepository: Repository<Club>,
+    @InjectRepository(Player)
+    private playersRepository: Repository<Player>,
   ) {}
 
   private async verifyClubAccess(clubId: string, user: JwtPayload) {
@@ -34,13 +37,72 @@ export class TeamsService {
     return club;
   }
 
-  async findByClub(clubId: string, user: JwtPayload): Promise<Team[]> {
-    await this.verifyClubAccess(clubId, user);
+  private async resolvePlayers(playerIds?: string[]): Promise<Player[]> {
+    if (!playerIds || playerIds.length === 0) {
+      return [];
+    }
 
-    return this.teamsRepository.find({
-      where: { clubId },
-      order: { name: 'ASC' },
+    const players = await this.playersRepository.find({
+      where: { id: In(playerIds) },
     });
+
+    if (players.length !== playerIds.length) {
+      throw new NotFoundException('One or more players were not found');
+    }
+
+    return players;
+  }
+
+  private async findByIdOrFail(id: string): Promise<Team> {
+    const team = await this.teamsRepository.findOne({
+      where: { id },
+      relations: ['club', 'players'],
+    });
+
+    if (!team) {
+      throw new NotFoundException(`Team with ID ${id} not found`);
+    }
+
+    return team;
+  }
+
+  private async verifyTeamAccess(id: string, user: JwtPayload): Promise<Team> {
+    const team = await this.findByIdOrFail(id);
+
+    if (user.role !== UserRole.ADMIN && team.club.organizerId !== user.sub) {
+      throw new ForbiddenException('You can only manage teams for your own clubs');
+    }
+
+    return team;
+  }
+
+  async findAll(filters: TeamFilterDto, user: JwtPayload): Promise<Team[]> {
+    const queryBuilder = this.teamsRepository
+      .createQueryBuilder('team')
+      .leftJoinAndSelect('team.players', 'players')
+      .leftJoinAndSelect('team.club', 'club');
+
+    if (filters.clubId) {
+      await this.verifyClubAccess(filters.clubId, user);
+      queryBuilder.andWhere('team.clubId = :clubId', { clubId: filters.clubId });
+    } else if (user.role !== UserRole.ADMIN) {
+      queryBuilder.andWhere('club.organizerId = :organizerId', {
+        organizerId: user.sub,
+      });
+    }
+
+    if (filters.search) {
+      queryBuilder.andWhere(
+        '(LOWER(team.name) LIKE LOWER(:search) OR LOWER(team.coach) LIKE LOWER(:search) OR LOWER(team.ageCategory) LIKE LOWER(:search))',
+        { search: `%${filters.search}%` },
+      );
+    }
+
+    return queryBuilder.orderBy('team.name', 'ASC').getMany();
+  }
+
+  async findOne(id: string, user: JwtPayload): Promise<Team> {
+    return this.verifyTeamAccess(id, user);
   }
 
   async create(user: JwtPayload, dto: CreateTeamDto): Promise<Team> {
@@ -57,8 +119,102 @@ export class TeamsService {
     const team = this.teamsRepository.create({
       clubId: dto.clubId,
       name: dto.name,
+      ageCategory: dto.ageCategory,
+      birthyear: dto.birthyear,
+      coach: dto.coach,
     });
 
+    if (dto.playerIds) {
+      team.players = await this.resolvePlayers(dto.playerIds);
+    }
+
     return this.teamsRepository.save(team);
+  }
+
+  async update(id: string, user: JwtPayload, dto: UpdateTeamDto): Promise<Team> {
+    const team = await this.verifyTeamAccess(id, user);
+
+    const targetClubId = dto.clubId ?? team.clubId;
+    const targetName = dto.name ?? team.name;
+
+    if (dto.clubId && dto.clubId !== team.clubId) {
+      await this.verifyClubAccess(dto.clubId, user);
+    }
+
+    const existing = await this.teamsRepository.findOne({
+      where: {
+        clubId: targetClubId,
+        name: targetName,
+        id: Not(team.id),
+      },
+    });
+
+    if (existing) {
+      throw new ConflictException('Team with this name already exists');
+    }
+
+    if (dto.clubId !== undefined) {
+      team.clubId = dto.clubId;
+    }
+
+    if (dto.name !== undefined) {
+      team.name = dto.name;
+    }
+
+    if (dto.ageCategory !== undefined) {
+      team.ageCategory = dto.ageCategory;
+    }
+
+    if (dto.birthyear !== undefined) {
+      team.birthyear = dto.birthyear;
+    }
+
+    if (dto.coach !== undefined) {
+      team.coach = dto.coach;
+    }
+
+    if (dto.playerIds !== undefined) {
+      team.players = await this.resolvePlayers(dto.playerIds);
+    }
+
+    return this.teamsRepository.save(team);
+  }
+
+  async remove(id: string, user: JwtPayload): Promise<void> {
+    const team = await this.verifyTeamAccess(id, user);
+    await this.teamsRepository.remove(team);
+  }
+
+  async search(
+    query: string,
+    user: JwtPayload,
+    clubId?: string,
+    limit: number = 10,
+  ): Promise<Team[]> {
+    if (!query?.trim()) {
+      return [];
+    }
+
+    const safeLimit = Math.min(Math.max(limit || 10, 1), 50);
+
+    const queryBuilder = this.teamsRepository
+      .createQueryBuilder('team')
+      .leftJoinAndSelect('team.players', 'players')
+      .leftJoin('team.club', 'club')
+      .where(
+        '(LOWER(team.name) LIKE LOWER(:query) OR LOWER(team.coach) LIKE LOWER(:query) OR LOWER(team.ageCategory) LIKE LOWER(:query))',
+        { query: `%${query}%` },
+      );
+
+    if (clubId) {
+      await this.verifyClubAccess(clubId, user);
+      queryBuilder.andWhere('team.clubId = :clubId', { clubId });
+    } else if (user.role !== UserRole.ADMIN) {
+      queryBuilder.andWhere('club.organizerId = :organizerId', {
+        organizerId: user.sub,
+      });
+    }
+
+    return queryBuilder.orderBy('team.name', 'ASC').take(safeLimit).getMany();
   }
 }


### PR DESCRIPTION
## Summary
Implements the backend API for **Issue #87 - Teams and Players entities and endpoints**.

## Changes

### New Module: Players
- `Player` entity with `id`, `firstname`, `lastname`, `dateOfBirth`, many-to-many relation to `Team`
- `PlayersController` — Full REST API:
  - `GET /v1/players` — List with optional `teamId`, `search`, pagination
  - `GET /v1/players/search?q=` — Search by name
  - `GET /v1/players/autocomplete?q=` — Autocomplete (returns id, firstname, lastname, label)
  - `GET /v1/players/:id` — Get by ID with teams relation
  - `POST /v1/players` — Create with optional `teamIds`
  - `PATCH /v1/players/:id` — Update with optional `teamIds`
  - `DELETE /v1/players/:id` — Delete
- `PlayersService` with full business logic
- DTOs: `CreatePlayerDto`, `UpdatePlayerDto`

### Modified: Teams Module
- `Team` entity — Added `ageCategory`, `birthyear`, `coach` columns + `players` many-to-many relation via `team_players` join table
- `TeamsController` — Added `PATCH`, `DELETE`, `GET /search` endpoints
- `TeamsService` — Added `update`, `remove`, `search` methods with player assignment support
- DTOs — Added `UpdateTeamDto`, expanded `CreateTeamDto` with new fields and `playerIds`

### App Module
- Registered `PlayersModule` in `AppModule` imports

Closes #87