### PR TITLE
feat: Issue #88 price entity and registration payment flow (backend)

### DIFF
--- a/src/common/entities/index.ts
+++ b/src/common/entities/index.ts
@@ -1,0 +1,1 @@
+export * from './price.entity';

--- a/src/common/entities/price.entity.ts
+++ b/src/common/entities/price.entity.ts
@@ -1,0 +1,23 @@
+import { Column } from 'typeorm';
+import { Currency } from '../enums';
+
+/**
+ * Price embeddable value object: stores amount + currency as a reusable unit.
+ * Embed in any entity that needs to represent a monetary value.
+ */
+export class Price {
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+    default: 0,
+  })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: Currency,
+    default: Currency.EUR,
+  })
+  currency: Currency;
+}

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -21,6 +21,7 @@ export enum TournamentLevel {
 
 export enum RegistrationStatus {
   PENDING = 'PENDING',
+  PENDING_PAYMENT = 'PENDING_PAYMENT',
   APPROVED = 'APPROVED',
   REJECTED = 'REJECTED',
   WITHDRAWN = 'WITHDRAWN',

--- a/src/modules/mail/mail.service.ts
+++ b/src/modules/mail/mail.service.ts
@@ -162,6 +162,70 @@ Football Tournament Platform
     return this.sendEmail(email, subject, htmlContent, textContent);
   }
 
+  /**
+   * Send payment pending email when registration is approved with pending payment (Issue #88).
+   */
+  async sendPaymentPendingEmail(
+    email: string,
+    userName: string,
+    tournamentName: string,
+    teamName: string,
+    amount: number,
+    currency: string,
+    registrationId: string,
+  ): Promise<boolean> {
+    const dashboardUrl = `${this.frontendUrl}/dashboard/registrations/${registrationId}`;
+    const subject = `Payment Required – ${tournamentName}`;
+
+    const formattedAmount = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency || 'EUR',
+    }).format(amount);
+
+    const htmlContent = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #1E40AF;">Payment Required for Tournament Registration</h2>
+        <p>Hello ${userName},</p>
+        <p>Your registration for <strong>${tournamentName}</strong> (team: <strong>${teamName}</strong>) has been approved and is now awaiting payment.</p>
+        <div style="background: #FEF3C7; border-left: 4px solid #F59E0B; padding: 16px; border-radius: 4px; margin: 20px 0;">
+          <p style="margin: 0; font-size: 18px; font-weight: bold; color: #92400E;">
+            Amount Due: ${formattedAmount}
+          </p>
+        </div>
+        <p>Please complete the payment to finalize your registration.</p>
+        <div style="text-align: center; margin: 30px 0;">
+          <a href="${dashboardUrl}"
+             style="background-color: #1E40AF; color: white; padding: 12px 30px; text-decoration: none; border-radius: 6px; display: inline-block;">
+            View Registration
+          </a>
+        </div>
+        <p style="color: #666;">If you have any questions, please contact the tournament organizer.</p>
+        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+        <p style="color: #888; font-size: 12px;">Football Tournament Platform</p>
+      </div>
+    `;
+
+    const textContent = `
+Payment Required for Tournament Registration
+
+Hello ${userName},
+
+Your registration for ${tournamentName} (team: ${teamName}) has been approved and is now awaiting payment.
+
+Amount Due: ${formattedAmount}
+
+Please complete the payment to finalize your registration.
+View your registration: ${dashboardUrl}
+
+If you have any questions, please contact the tournament organizer.
+
+---
+Football Tournament Platform
+    `.trim();
+
+    return this.sendEmail(email, subject, htmlContent, textContent);
+  }
+
   private async sendEmail(
     to: string,
     subject: string,

--- a/src/modules/registrations/dto/registration.dto.ts
+++ b/src/modules/registrations/dto/registration.dto.ts
@@ -4,13 +4,14 @@ import {
   IsNumber,
   IsEnum,
   IsArray,
+  IsBoolean,
   Min,
   Max,
   IsUUID,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { RegistrationStatus, PaymentStatus } from '../../../common/enums';
+import { RegistrationStatus, PaymentStatus, Currency } from '../../../common/enums';
 import { PaginationDto } from '../../../common/dto';
 
 export class CreateRegistrationDto {
@@ -170,6 +171,26 @@ export class BulkReviewDto {
   @ApiPropertyOptional({
     example: 'Bulk approval for verified teams.',
     description: 'Notes for all registrations being processed'
+  })
+  @IsOptional()
+  @IsString()
+  reviewNotes?: string;
+}
+
+export class MarkAsPaidDto {
+  @ApiPropertyOptional({
+    example: 150.00,
+    description: 'Amount paid (defaults to the registration price if omitted)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  paidAmount?: number;
+
+  @ApiPropertyOptional({
+    example: 'Paid via bank transfer on 2026-02-16',
+    description: 'Notes about the payment',
   })
   @IsOptional()
   @IsString()

--- a/src/modules/registrations/entities/registration.entity.ts
+++ b/src/modules/registrations/entities/registration.entity.ts
@@ -10,7 +10,7 @@ import {
   Index,
   JoinColumn,
 } from 'typeorm';
-import { RegistrationStatus, PaymentStatus } from '../../../common/enums';
+import { RegistrationStatus, PaymentStatus, Currency } from '../../../common/enums';
 import { Tournament } from '../../tournaments/entities/tournament.entity';
 import { TournamentAgeGroup } from '../../tournaments/entities/tournament-age-group.entity';
 import { Club } from '../../clubs/entities/club.entity';
@@ -137,6 +137,36 @@ export class Registration {
 
   @Column({ name: 'fitness_notes', type: 'text', nullable: true })
   fitnessNotes?: string;
+
+  // ----- Price / payment tracking (Issue #88) -----
+  @Column({
+    name: 'price_amount',
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+    nullable: true,
+  })
+  priceAmount?: number;
+
+  @Column({
+    name: 'price_currency',
+    type: 'enum',
+    enum: Currency,
+    nullable: true,
+  })
+  priceCurrency?: Currency;
+
+  @Column({ name: 'paid', default: false })
+  paid: boolean;
+
+  @Column({
+    name: 'paid_amount',
+    type: 'decimal',
+    precision: 10,
+    scale: 2,
+    nullable: true,
+  })
+  paidAmount?: number;
 
   @OneToOne(() => Payment, (payment) => payment.registration)
   payment: Payment;

--- a/src/modules/registrations/registrations.controller.ts
+++ b/src/modules/registrations/registrations.controller.ts
@@ -30,6 +30,7 @@ import {
   BulkReviewDto,
   UploadDocumentDto,
   ConfirmFitnessDto,
+  MarkAsPaidDto,
 } from './dto';
 import { JwtAuthGuard, RolesGuard } from '../auth/guards';
 import { Roles, CurrentUser, Public } from '../../common/decorators';
@@ -206,6 +207,17 @@ export class RegistrationsController {
     @Body() dto: RejectRegistrationDto,
   ) {
     return this.registrationsService.reject(id, user.sub, user.role, dto);
+  }
+
+  @Post('registrations/:id/mark-as-paid')
+  @ApiOperation({ summary: 'Mark registration as paid' })
+  @ApiResponse({ status: 200, description: 'Registration marked as paid' })
+  markAsPaid(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: MarkAsPaidDto,
+  ) {
+    return this.registrationsService.markAsPaid(id, user.sub, user.role, dto);
   }
 
   @Post('tournaments/:tournamentId/registrations/bulk-approve')


### PR DESCRIPTION
Implements Issue #88 backend changes:
- Add reusable Price entity (amount + currency)
- Add registration payment tracking fields (`priceAmount`, `priceCurrency`, `paid`, `paidAmount`)
- Add `PENDING_PAYMENT` registration status
- Add `mark-as-paid` endpoint and service logic
- Add payment-pending email flow

Includes end-to-end tested flow support with frontend.
