### PR TITLE
fix: make team entity columns nullable to support schema migration

### DIFF
--- a/src/modules/teams/entities/team.entity.ts
+++ b/src/modules/teams/entities/team.entity.ts
@@ -32,13 +32,13 @@ export class Team {
   @Column()
   name: string;
 
-  @Column({ name: 'age_category' })
+  @Column({ name: 'age_category', nullable: true })
   ageCategory: string;
 
-  @Column({ type: 'int' })
+  @Column({ type: 'int', nullable: true })
   birthyear: number;
 
-  @Column()
+  @Column({ nullable: true })
   coach: string;
 
   @CreateDateColumn({ name: 'created_at' })


### PR DESCRIPTION
- Add nullable: true to age_category, birthyear, and coach columns
- Fixes schema sync errors when adding NOT NULL columns to existing tables with data
- Allows TypeORM to successfully migrate existing teams table