### PR TITLE
fix: propagate losers to third place match in single elimination brackets

### DIFF
--- a/src/modules/groups/services/bracket-generator.service.ts
+++ b/src/modules/groups/services/bracket-generator.service.ts
@@ -362,17 +362,34 @@ export class BracketGeneratorService {
    * Link matches for single elimination (winner advances)
    */
   private linkSingleEliminationMatches(playoffRounds: PlayoffRound[]): void {
+    // Find the third place round if it exists
+    const thirdPlaceRound = playoffRounds.find(
+      (r) => r.roundName === 'Third Place',
+    );
+    const thirdPlaceMatchId = thirdPlaceRound?.matches?.[0]?.id;
+
+    // Find the semi-finals round (the round right before the Final)
+    const finalRound = playoffRounds.find((r) => r.roundName === 'Final');
+
     for (let i = 0; i < playoffRounds.length - 1; i++) {
       const currentRound = playoffRounds[i];
       const nextRound = playoffRounds[i + 1];
 
-      // Skip third place match round if it exists
+      // Skip third place match round for winner linking
       if (nextRound.roundName === 'Third Place') continue;
 
       currentRound.matches.forEach((match, index) => {
         const nextMatchIndex = Math.floor(index / 2);
         if (nextRound.matches[nextMatchIndex]) {
           match.nextMatchId = nextRound.matches[nextMatchIndex].id;
+        }
+
+        // Link semi-final losers to third place match
+        if (
+          thirdPlaceMatchId &&
+          nextRound.roundName === 'Final'
+        ) {
+          match.loserNextMatchId = thirdPlaceMatchId;
         }
       });
     }


### PR DESCRIPTION
## Summary
Fixes the "TBD vs TBD" bug in the Third Place match after semi-finals are scored in single elimination brackets.

## Root Cause
Two issues caused this bug:
1. **bracket-generator.service.ts**: The `linkSingleEliminationMatches` method never set `loserNextMatchId` on semi-final matches, skipping the Third Place round entirely
2. **groups.service.ts**: There was no logic to propagate losing teams to subsequent matches (only winners were propagated)

## Changes Made
### bracket-generator.service.ts
- Modified `linkSingleEliminationMatches` to find the Third Place match and set `loserNextMatchId` on semi-final matches pointing to it

### groups.service.ts
- Added new `propagateLoser` method to handle loser advancement
- Called `propagateLoser` from all three advancement code paths:
  - `setMatchAdvancement` (explicit advancement)
  - `updateMatchScore` manual path
  - `updateMatchScore` auto-score path

## Testing
✅ API testing confirmed correct behavior:
- SF1 winner → team1 of Final
- SF1 loser → team1 of Third Place
- SF2 winner → team2 of Final
- SF2 loser → team2 of Third Place

✅ Browser UI testing on production (tournamente.com):
- Third Place match correctly populated with losing teams
- Scoring worked correctly
- Edit Score functionality verified
- Manual Advance functionality verified
- Public page displays bracket correctly

## Screenshots
All test screenshots saved to `notes/issue-173/screenshots/2026-02-17/`