### PR TITLE
feat(tournaments): add numberOfFields to tournament entity and DTOs [#101]

### DIFF
--- a/src/modules/tournaments/dto/tournament.dto.ts
+++ b/src/modules/tournaments/dto/tournament.dto.ts
@@ -183,6 +183,14 @@ export class CreateAgeGroupDto {
   @Min(1)
   groupsCount?: number;
 
+  @ApiPropertyOptional({ example: 2, description: 'Number of playing fields (simultaneous games) for this age category' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(50)
+  fieldsCount?: number;
+
   @ApiPropertyOptional({ example: 4, description: 'Teams per group' })
   @IsOptional()
   @Type(() => Number)
@@ -308,6 +316,14 @@ export class UpdateAgeGroupDto {
   @IsNumber()
   @Min(1)
   groupsCount?: number;
+
+  @ApiPropertyOptional({ example: 2, description: 'Number of playing fields (simultaneous games) for this age category' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(50)
+  fieldsCount?: number;
 
   @ApiPropertyOptional({ example: 4, description: 'Teams per group' })
   @IsOptional()
@@ -663,6 +679,14 @@ export class CreateTournamentDto {
   @IsBoolean()
   thirdPlaceMatch?: boolean;
 
+  @ApiPropertyOptional({ example: 4, description: 'Total number of playing fields/grounds available for the tournament' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  numberOfFields?: number;
+
   // Regulations
   @ApiPropertyOptional({
     enum: ['UPLOADED', 'GENERATED'],
@@ -904,6 +928,14 @@ export class UpdateTournamentDto {
   @IsOptional()
   @IsBoolean()
   thirdPlaceMatch?: boolean;
+
+  @ApiPropertyOptional({ example: 4, description: 'Total number of playing fields/grounds available for the tournament' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  numberOfFields?: number;
 
   // Regulations
   @ApiPropertyOptional({

--- a/src/modules/tournaments/entities/tournament-age-group.entity.ts
+++ b/src/modules/tournaments/entities/tournament-age-group.entity.ts
@@ -132,6 +132,10 @@ export class TournamentAgeGroup {
   @Column({ name: 'groups_count', nullable: true })
   groupsCount?: number;
 
+  // Number of playing fields (simultaneous games)
+  @Column({ name: 'fields_count', nullable: true })
+  fieldsCount?: number;
+
   @Column({ name: 'teams_per_group', default: 4 })
   teamsPerGroup: number;
 

--- a/src/modules/tournaments/entities/tournament.entity.ts
+++ b/src/modules/tournaments/entities/tournament.entity.ts
@@ -245,6 +245,10 @@ export class Tournament {
   @Column({ nullable: true })
   country?: string;
 
+  // Total number of playing fields/grounds available for the tournament
+  @Column({ name: 'number_of_fields', nullable: true })
+  numberOfFields?: number;
+
   // Group Configuration (Issue #41)
   @Column({ name: 'number_of_groups', nullable: true })
   numberOfGroups?: number;

--- a/src/modules/tournaments/tournaments.service.ts
+++ b/src/modules/tournaments/tournaments.service.ts
@@ -532,7 +532,7 @@ export class TournamentsService {
     tournamentId: string,
     userId: string,
     userRole: string,
-    ageGroups: { id?: string; birthYear: number; displayLabel?: string; ageCategory?: string; level?: string; format?: string; gameSystem?: string; teamCount?: number; minTeams?: number; numberOfMatches?: number; matchPeriodType?: 'ONE_HALF' | 'TWO_HALVES'; halfDurationMinutes?: number; startDate?: string; endDate?: string; locationId?: string; locationAddress?: string; participationFee?: number; groupsCount?: number; teamsPerGroup?: number }[],
+    ageGroups: { id?: string; birthYear: number; displayLabel?: string; ageCategory?: string; level?: string; format?: string; gameSystem?: string; teamCount?: number; minTeams?: number; numberOfMatches?: number; matchPeriodType?: 'ONE_HALF' | 'TWO_HALVES'; halfDurationMinutes?: number; startDate?: string; endDate?: string; locationId?: string; locationAddress?: string; participationFee?: number; groupsCount?: number; fieldsCount?: number; teamsPerGroup?: number }[],
   ): Promise<TournamentAgeGroup[]> {
     const tournament = await this.findByIdOrFail(tournamentId);
 


### PR DESCRIPTION
## Summary

Implements the backend part of [#101](https://github.com/Sport-Tournaments/sport-tournaments-backend/issues/101) — **Add number of fields/grounds to tournament model and endpoints**.

## Changes

### `tournament.entity.ts`
- Added `numberOfFields?: number` column (`number_of_fields`, nullable) to store total parallel playing fields for the tournament

### `tournament-age-group.entity.ts`
- Added `fieldsCount?: number` column (`fields_count`, nullable) to store per-age-group field allocation

### `tournament.dto.ts`
- Added `numberOfFields` to `CreateTournamentDto` (optional, 1–100, with Swagger docs)
- Added `numberOfFields` to `UpdateTournamentDto` (optional, 1–100, with Swagger docs)
- Added `fieldsCount` to `CreateAgeGroupDto` (optional, 1–50, with Swagger docs)
- Added `fieldsCount` to `UpdateAgeGroupDto` (optional, 1–50, with Swagger docs)

### `tournaments.service.ts`
- Updated `updateAgeGroups` method signature to include `fieldsCount` in the age group parameter type

## Testing

- API verified: `POST /api/v1/tournaments` with `numberOfFields: 3` → tournament created
- API verified: `GET /api/v1/tournaments/:id` returns `numberOfFields: 3`
- API verified: `PATCH /api/v1/tournaments/:id` with `numberOfFields: 5` → persisted correctly