### PR TITLE
feat(groups): BE-07/08/10/11/12 + bracket algorithm enhancements

### DIFF
--- a/src/modules/groups/dto/group.dto.ts
+++ b/src/modules/groups/dto/group.dto.ts
@@ -5,6 +5,7 @@ import {
   IsArray,
   Min,
   IsUUID,
+  IsISO8601,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -91,4 +92,21 @@ export class UpdateMatchScoreDto {
   @IsOptional()
   @IsString()
   status?: string;
+}
+
+/** BE-07 — Schedule a match (set date/time and optional court number) */
+export class ScheduleMatchDto {
+  @ApiProperty({
+    example: '2026-07-15T09:00:00Z',
+    description: 'ISO 8601 datetime when the match is scheduled to start',
+  })
+  @IsISO8601()
+  scheduledAt: string;
+
+  @ApiPropertyOptional({ example: 3, description: 'Court / field number' })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  courtNumber?: number;
 }

--- a/src/modules/groups/groups.controller.ts
+++ b/src/modules/groups/groups.controller.ts
@@ -18,7 +18,7 @@ import {
 } from '@nestjs/swagger';
 import { GroupsService } from './groups.service';
 import { PotDrawService } from './services/pot-draw.service';
-import { ExecuteDrawDto, UpdateBracketDto, CreateGroupDto, ConfigureGroupsDto, UpdateGroupDto, GroupConfigurationResponseDto, UpdateMatchAdvancementDto, UpdateMatchScoreDto } from './dto';
+import { ExecuteDrawDto, UpdateBracketDto, CreateGroupDto, ConfigureGroupsDto, UpdateGroupDto, GroupConfigurationResponseDto, UpdateMatchAdvancementDto, UpdateMatchScoreDto, ScheduleMatchDto } from './dto';
 import { AssignTeamToPotDto, AssignPotsBulkDto, ExecutePotDrawDto } from './dto/pot.dto';
 import { JwtAuthGuard, RolesGuard } from '../auth/guards';
 import { CurrentUser, Public } from '../../common/decorators';
@@ -200,6 +200,28 @@ export class GroupsController {
     @Query('ageGroupId') ageGroupId?: string,
   ) {
     return this.groupsService.updateMatchScore(
+      tournamentId,
+      matchId,
+      user.sub,
+      user.role,
+      dto,
+      ageGroupId,
+    );
+  }
+
+  @Patch('matches/:matchId/schedule')
+  @ApiOperation({ summary: 'Schedule a match — set date/time and court number (BE-07)' })
+  @ApiResponse({ status: 200, description: 'Match scheduled' })
+  @ApiResponse({ status: 403, description: 'Not authorized (organizer only)' })
+  @ApiResponse({ status: 404, description: 'Match not found' })
+  scheduleMatch(
+    @Param('tournamentId', ParseUUIDPipe) tournamentId: string,
+    @Param('matchId') matchId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: ScheduleMatchDto,
+    @Query('ageGroupId') ageGroupId?: string,
+  ) {
+    return this.groupsService.scheduleMatch(
       tournamentId,
       matchId,
       user.sub,

--- a/src/modules/groups/groups.module.ts
+++ b/src/modules/groups/groups.module.ts
@@ -5,12 +5,13 @@ import { GroupsController } from './groups.controller';
 import { Group } from './entities/group.entity';
 import { TournamentPot } from './entities/tournament-pot.entity';
 import { Tournament } from '../tournaments/entities/tournament.entity';
+import { TournamentAgeGroup } from '../tournaments/entities/tournament-age-group.entity';
 import { Registration } from '../registrations/entities/registration.entity';
 import { BracketGeneratorService } from './services/bracket-generator.service';
 import { PotDrawService } from './services/pot-draw.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Group, TournamentPot, Tournament, Registration])],
+  imports: [TypeOrmModule.forFeature([Group, TournamentPot, Tournament, TournamentAgeGroup, Registration])],
   controllers: [GroupsController],
   providers: [GroupsService, BracketGeneratorService, PotDrawService],
   exports: [GroupsService, BracketGeneratorService, PotDrawService],

--- a/src/modules/groups/groups.service.ts
+++ b/src/modules/groups/groups.service.ts
@@ -9,12 +9,14 @@ import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { Group } from './entities/group.entity';
 import { Tournament } from '../tournaments/entities/tournament.entity';
+import { TournamentAgeGroup } from '../tournaments/entities/tournament-age-group.entity';
 import { Registration } from '../registrations/entities/registration.entity';
 import { ExecuteDrawDto, UpdateBracketDto, CreateGroupDto, ConfigureGroupsDto, UpdateGroupDto, GroupConfigurationResponseDto, UpdateMatchAdvancementDto, UpdateMatchScoreDto } from './dto';
 import {
   TournamentStatus,
   RegistrationStatus,
   UserRole,
+  TournamentFormat,
 } from '../../common/enums';
 import { BracketGeneratorService, BracketType, Match } from './services/bracket-generator.service';
 
@@ -25,6 +27,8 @@ export class GroupsService {
     private groupsRepository: Repository<Group>,
     @InjectRepository(Tournament)
     private tournamentsRepository: Repository<Tournament>,
+    @InjectRepository(TournamentAgeGroup)
+    private ageGroupRepository: Repository<TournamentAgeGroup>,
     @InjectRepository(Registration)
     private registrationsRepository: Repository<Registration>,
     private bracketGeneratorService: BracketGeneratorService,
@@ -140,6 +144,12 @@ export class GroupsService {
       drawCompleted: true,
       drawSeed: seed,
     });
+
+    // BE-08 — auto-calculate numberOfMatches for affected age groups
+    const ageGroupIds = [...new Set(registrations.map((r) => r.ageGroupId).filter(Boolean))];
+    for (const agId of ageGroupIds) {
+      await this.autoCalcNumberOfMatches(tournamentId, agId!, savedGroups.filter(g => g.teams.some(t => registrations.find(r => r.id === t)?.ageGroupId === agId)));
+    }
 
     return savedGroups;
   }
@@ -635,6 +645,33 @@ export class GroupsService {
     return null;
   }
 
+  /**
+   * Searches bracketData (playoffRounds[].matches and top-level matches) for a
+   * match with the given matchId. Returns the match object reference so callers
+   * can mutate it in-place.
+   */
+  private findMatchInBracket(bracketData: any, matchId: string): any | null {
+    if (!bracketData) return null;
+
+    // Search inside playoffRounds
+    if (Array.isArray(bracketData.playoffRounds)) {
+      for (const round of bracketData.playoffRounds) {
+        if (Array.isArray(round.matches)) {
+          const match = round.matches.find((m: any) => m.id === matchId);
+          if (match) return match;
+        }
+      }
+    }
+
+    // Search top-level matches array
+    if (Array.isArray(bracketData.matches)) {
+      const match = bracketData.matches.find((m: any) => m.id === matchId);
+      if (match) return match;
+    }
+
+    return null;
+  }
+
   async getMatches(tournamentId: string, ageGroupId?: string): Promise<{
     matches: Match[];
     bracketType?: string;
@@ -937,6 +974,52 @@ export class GroupsService {
     return { match: targetMatch, bracketUpdated };
   }
 
+  /**
+   * BE-07 — Schedule a match: sets scheduledAt and optional courtNumber.
+   * Only the tournament organizer (or admin) may call this.
+   */
+  async scheduleMatch(
+    tournamentId: string,
+    matchId: string,
+    userId: string,
+    userRole: string,
+    dto: { scheduledAt: string; courtNumber?: number },
+    ageGroupId?: string,
+  ): Promise<any> {
+    const tournament = await this.tournamentsRepository.findOne({
+      where: { id: tournamentId },
+    });
+
+    if (!tournament) {
+      throw new NotFoundException('Tournament not found');
+    }
+
+    if (tournament.organizerId !== userId && userRole !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'Only the tournament organizer can schedule matches',
+      );
+    }
+
+    const fullBracketData: any = tournament.bracketData || {};
+    const bracketData = this.getBracketForAgeGroup(fullBracketData, ageGroupId) || fullBracketData;
+
+    const targetMatch = this.findMatchInBracket(bracketData, matchId);
+    if (!targetMatch) {
+      throw new NotFoundException(`Match ${matchId} not found in bracket`);
+    }
+
+    targetMatch.scheduledAt = new Date(dto.scheduledAt) as any;
+    if (dto.courtNumber !== undefined) {
+      (targetMatch as any).courtNumber = dto.courtNumber;
+    }
+
+    await this.tournamentsRepository.update(tournamentId, {
+      bracketData: fullBracketData,
+    });
+
+    return targetMatch;
+  }
+
   async generateBracket(
     tournamentId: string,
     userId: string,
@@ -945,6 +1028,7 @@ export class GroupsService {
   ): Promise<any> {
     const tournament = await this.tournamentsRepository.findOne({
       where: { id: tournamentId },
+      relations: ['ageGroups'],
     });
 
     if (!tournament) {
@@ -975,17 +1059,24 @@ export class GroupsService {
       );
     }
 
-    // Determine bracket type from tournament config
-    const bracketType = (tournament as any).bracketType
-      || BracketType.SINGLE_ELIMINATION;
+    // BE-10: Determine bracket type from the age group's persisted format column.
+    // The previous cast `(tournament as any).bracketType` was always undefined
+    // because Tournament has no such property.
+    const ageGroup = ageGroupId
+      ? (tournament.ageGroups ?? []).find((ag) => ag.id === ageGroupId)
+      : null;
+    const bracketType: BracketType =
+      ((ageGroup?.format as unknown as BracketType) ??
+        BracketType.SINGLE_ELIMINATION);
 
     const bracketData = this.bracketGeneratorService.generateBracket(
-      bracketType as BracketType,
+      bracketType,
       registrations.length,
       {
-        groupCount: tournament.numberOfGroups,
+        groupCount: ageGroup?.groupsCount ?? tournament.numberOfGroups,
         thirdPlaceMatch: true,
         seed: tournament.drawSeed || undefined,
+        leagueLegs: 2, // default; BE-11: will use ageGroup.leagueLegs once column is added
       },
     );
 
@@ -1170,5 +1261,50 @@ export class GroupsService {
       hash = hash & hash;
     }
     return Math.abs(hash);
+  }
+
+  /**
+   * BE-08 — Auto-calculate numberOfMatches for a TournamentAgeGroup after the
+   * group draw has been executed.
+   *
+   * Formula for GROUPS_PLUS_KNOCKOUT:
+   *   groupMatches = numGroups × C(teamsPerGroup, 2)          (round-robin within each group)
+   *   knockoutMatches = qualifyingTeams – 1                   (single-elim tree; each match eliminates one team)
+   *   total = groupMatches + knockoutMatches + 1              (+ 1 for 3rd-place match)
+   */
+  private async autoCalcNumberOfMatches(
+    tournamentId: string,
+    ageGroupId: string,
+    groups: Group[],
+  ): Promise<void> {
+    try {
+      const ageGroup = await this.ageGroupRepository.findOne({
+        where: { id: ageGroupId, tournamentId },
+      });
+      if (!ageGroup) return;
+
+      const numGroups = groups.length;
+      if (numGroups === 0) return;
+
+      const teamsPerGroup = Math.ceil(
+        groups.reduce((s, g) => s + g.teams.length, 0) / numGroups,
+      );
+
+      // C(n, 2) = n*(n-1)/2
+      const groupMatches = numGroups * ((teamsPerGroup * (teamsPerGroup - 1)) / 2);
+
+      // Default 2 advancing per group (can be overridden in future via ageGroup.advancingPerGroup)
+      const advancingPerGroup = 2;
+      const qualifyingTeams = numGroups * advancingPerGroup;
+
+      const knockoutMatches = qualifyingTeams - 1;
+      const total = groupMatches + knockoutMatches + 1; // +1 third-place match
+
+      await this.ageGroupRepository.update(ageGroupId, {
+        numberOfMatches: total,
+      });
+    } catch {
+      // Non-critical — silently skip if calculation fails
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR covers multiple backend enhancements to the Groups module, bracket generation, and pot draw service.

---

### BE-07 — Match Scheduling
- Added `ScheduleMatchDto` (ISO 8601 `scheduledAt` + optional `courtNumber`)
- New `PATCH /tournaments/:id/matches/:matchId/schedule` endpoint
- `GroupsService.scheduleMatch()` — organizer-only, persists to `bracketData`
- `BracketMatch` interface extended with `courtNumber?: number`

### BE-08 — Auto-calculate `numberOfMatches`
- After draw execution, `autoCalcNumberOfMatches()` computes group-stage + knockout + 3rd-place match totals for each affected `TournamentAgeGroup`
- `TournamentAgeGroup` repository injected into `GroupsService`

### BE-10 — Bracket type from age group format
- `generateBracket()` now reads `ageGroup.format` column instead of the non-existent `tournament.bracketType`
- Falls back to `SINGLE_ELIMINATION` when no age group is specified

### BE-11 — League bracket
- New `BracketType.LEAGUE` enum value
- `generateLeagueBracket(teamCount, legs)` — full round-robin with configurable home/away legs
- Uses Berger wheel-rotation for conflict-free scheduling

### BE-12 — Pot draw format gating
- `executePotBasedDraw()` blocks `ROUND_ROBIN` format (pot draw not applicable)
- Allows SE/DE/LEAGUE formats through for seeding-order draw
- `TournamentAgeGroup` repository injected into `PotDrawService`

### BE-SE-01 — Single elimination BYE slots
- Non-power-of-2 team counts now get BYE matches in round 1 (`autoAdvance: true, team2Id: 'BYE'`)
- `PlayoffRound.bracket = 'winners'` tagged

### BE-DE-01 — Double elimination loser wiring
- `loserNextMatchId` properly wired from each winners-bracket match to the correct losers-bracket match
- Losers bracket rounds tagged with `bracket: 'losers'`; grand final with `bracket: 'grand_final'`
- Round names improved: "Winners Final", "Losers Final", "Grand Finals"

### PM-01 — Round-robin Berger algorithm
- Replaced naive nested-loop pairing with circle/wheel-rotation algorithm
- Guarantees no team plays twice in the same round; odd team counts handled via dummy BYE slot

### PM-02 — Cross-group bracket seeding
- `seedTeamsIntoBracket()` now uses cross-group interleaving: `1A v 2B`, `1C v 2D`, `2A v 1B`, `2C v 1D`
- Ensures group winners avoid each other until at least semi-finals; falls back for odd group counts

### Fix — `findMatchInBracket` missing method
- Private helper that searches `playoffRounds[].matches` and top-level `matches` arrays by `matchId`
- Was called at line 979 but never defined, causing TS compile error

---

### Files Changed
- `src/modules/groups/dto/group.dto.ts`
- `src/modules/groups/groups.controller.ts`
- `src/modules/groups/groups.module.ts`
- `src/modules/groups/groups.service.ts`
- `src/modules/groups/services/bracket-generator.service.ts`
- `src/modules/groups/services/pot-draw.service.ts`