### PR TITLE
feat(groups): pot-based draw with remainder support and dynamic pot count

### DIFF
--- a/src/modules/groups/dto/group.dto.ts
+++ b/src/modules/groups/dto/group.dto.ts
@@ -109,4 +109,9 @@ export class ScheduleMatchDto {
   @IsNumber()
   @Min(1)
   courtNumber?: number;
+
+  @ApiPropertyOptional({ example: 'Pitch 1', description: 'Football field name' })
+  @IsOptional()
+  @IsString()
+  fieldName?: string;
 }

--- a/src/modules/groups/dto/pot.dto.ts
+++ b/src/modules/groups/dto/pot.dto.ts
@@ -7,7 +7,7 @@ export class AssignTeamToPotDto {
 
   @IsNumber()
   @Min(1)
-  @Max(4)
+  @Max(32)
   potNumber: number;
 }
 

--- a/src/modules/groups/groups.controller.ts
+++ b/src/modules/groups/groups.controller.ts
@@ -283,12 +283,13 @@ export class GroupsController {
   ) {
     const potMap = await this.potDrawService.getPotAssignments(tournamentId, ageGroupId);
     
-    // Convert map to array format for API response
+    // Convert map to array format for API response (dynamic pot count)
     const result: any[] = [];
-    for (let i = 1; i <= 4; i++) {
-      const teams = potMap.get(i) || [];
+    const potNumbers = Array.from(potMap.keys()).sort((a, b) => a - b);
+    for (const potNum of potNumbers) {
+      const teams = potMap.get(potNum) || [];
       result.push({
-        potNumber: i,
+        potNumber: potNum,
         count: teams.length,
         teams: teams.map((t) => ({
           registrationId: t.registrationId,

--- a/src/modules/groups/groups.service.ts
+++ b/src/modules/groups/groups.service.ts
@@ -18,7 +18,7 @@ import {
   UserRole,
   TournamentFormat,
 } from '../../common/enums';
-import { BracketGeneratorService, BracketType, Match } from './services/bracket-generator.service';
+import { BracketGeneratorService, BracketType, GroupStanding, Match } from './services/bracket-generator.service';
 
 @Injectable()
 export class GroupsService {
@@ -716,8 +716,13 @@ export class GroupsService {
 
     const allMatches: Match[] = [];
 
-    // Collect matches from playoff rounds
-    if (ageBracket.playoffRounds) {
+    const isGroupFormat =
+      ageBracket.type === BracketType.GROUPS_PLUS_KNOCKOUT ||
+      ageBracket.type === BracketType.GROUPS_ONLY;
+
+    // For group formats, only standalone matches (group phase) go into allMatches.
+    // Knockout playoff rounds are returned separately and rendered via the bracket chart.
+    if (!isGroupFormat && ageBracket.playoffRounds) {
       for (const round of ageBracket.playoffRounds) {
         if (round.matches) {
           allMatches.push(...round.matches);
@@ -968,6 +973,64 @@ export class GroupsService {
       }
     }
 
+    // Auto-seed knockout bracket when ALL group-phase matches are completed
+    if (
+      targetMatch.groupLetter &&
+      targetMatch.status === 'COMPLETED' &&
+      bracketData.matches &&
+      bracketData.playoffRounds?.length > 0
+    ) {
+      const groupPhaseMatches = (bracketData.matches as Match[]);
+      const allGroupDone = groupPhaseMatches.length > 0 &&
+        groupPhaseMatches.every((m) => m.status === 'COMPLETED');
+
+      if (allGroupDone) {
+        // Fetch groups for this tournament
+        const groups = await this.groupsRepository.find({
+          where: { tournamentId },
+          order: { groupLetter: 'ASC' },
+        });
+
+        // Build a name map from group match data
+        const nameMap = new Map<string, string>();
+        for (const m of groupPhaseMatches) {
+          if (m.team1Id && m.team1Name) nameMap.set(m.team1Id, m.team1Name);
+          if (m.team2Id && m.team2Name) nameMap.set(m.team2Id, m.team2Name);
+        }
+
+        // Calculate standings per group
+        const perGroupStandings = new Map<string, GroupStanding[]>();
+        for (const group of groups) {
+          const gMatches = groupPhaseMatches.filter(
+            (m) => m.groupLetter === group.groupLetter,
+          );
+          const standings = this.bracketGeneratorService.calculateGroupStandings(
+            group.teams,
+            gMatches,
+          );
+          perGroupStandings.set(group.groupLetter, standings);
+        }
+
+        // Seed advancing teams into knockout bracket
+        const advancingPerGroup =
+          (bracketData as any).advancingTeamsPerGroup ?? 2;
+        this.bracketGeneratorService.seedTeamsIntoBracket(
+          perGroupStandings,
+          advancingPerGroup,
+          bracketData,
+        );
+
+        // Fill in team names on first-round knockout matches
+        const firstRound = bracketData.playoffRounds[0];
+        for (const m of firstRound.matches) {
+          if (m.team1Id) m.team1Name = nameMap.get(m.team1Id) || m.team1Name || '';
+          if (m.team2Id) m.team2Name = nameMap.get(m.team2Id) || m.team2Name || '';
+        }
+
+        bracketUpdated = true;
+      }
+    }
+
     // Save bracket data (fullBracketData contains the mutation via object reference)
     await this.tournamentsRepository.update(tournamentId, {
       bracketData: fullBracketData,
@@ -985,7 +1048,7 @@ export class GroupsService {
     matchId: string,
     userId: string,
     userRole: string,
-    dto: { scheduledAt: string; courtNumber?: number },
+    dto: { scheduledAt: string; courtNumber?: number; fieldName?: string },
     ageGroupId?: string,
   ): Promise<any> {
     const tournament = await this.tournamentsRepository.findOne({
@@ -1013,6 +1076,9 @@ export class GroupsService {
     targetMatch.scheduledAt = new Date(dto.scheduledAt) as any;
     if (dto.courtNumber !== undefined) {
       (targetMatch as any).courtNumber = dto.courtNumber;
+    }
+    if (dto.fieldName !== undefined) {
+      (targetMatch as any).fieldName = dto.fieldName;
     }
 
     await this.tournamentsRepository.update(tournamentId, {
@@ -1155,6 +1221,74 @@ export class GroupsService {
             'Team ' + (team2Index + 1);
         }
       });
+    }
+
+    // Generate group phase round-robin matches for GROUPS_PLUS_KNOCKOUT / GROUPS_ONLY
+    if (
+      bracketType === BracketType.GROUPS_PLUS_KNOCKOUT ||
+      bracketType === BracketType.GROUPS_ONLY
+    ) {
+      const groupsForRR = await this.groupsRepository.find({
+        where: { tournamentId },
+        order: { groupLetter: 'ASC' },
+      });
+      const rrRegIds = new Set(registrations.map((r) => r.id));
+      const rrRegMap = new Map(
+        registrations.map((r) => [r.id, r]),
+      );
+
+      const groupPhaseMatches: Match[] = [];
+      let rrCounter = 1;
+
+      for (const group of groupsForRR) {
+        const teams = group.teams.filter((id) => rrRegIds.has(id));
+        const n = teams.length;
+        if (n < 2) continue;
+        const nSlots = n % 2 === 0 ? n : n + 1; // add ghost slot for odd count
+
+        // Circle method: fix team 0, rotate 1..nSlots-1
+        // In round r, build permuted list ℓ:
+        //   ℓ[0] = 0 (fixed), ℓ[j] = (r + j - 1) % (nSlots - 1) + 1, j=1..nSlots-1
+        // Pair: ℓ[i] vs ℓ[nSlots-1-i] for i=0..nSlots/2-1
+        const numRounds = nSlots - 1;
+        for (let r = 0; r < numRounds; r++) {
+          const round = r + 1;
+          let matchInRound = 0;
+          const perm: number[] = [0];
+          for (let j = 1; j < nSlots; j++) {
+            perm.push(((r + j - 1) % (nSlots - 1)) + 1);
+          }
+
+          for (let i = 0; i < nSlots / 2; i++) {
+            const idx1 = perm[i];
+            const idx2 = perm[nSlots - 1 - i];
+            // Skip ghost slots (index >= n means BYE for odd team count)
+            if (idx1 >= n || idx2 >= n) continue;
+            matchInRound++;
+            const t1Id = teams[idx1];
+            const t2Id = teams[idx2];
+            groupPhaseMatches.push({
+              id: `grp_${group.groupLetter}_${rrCounter++}`,
+              round,
+              matchNumber: matchInRound,
+              status: 'PENDING',
+              groupLetter: group.groupLetter,
+              team1Id: t1Id,
+              team2Id: t2Id,
+              team1Name:
+                rrRegMap.get(t1Id)?.club?.name ||
+                rrRegMap.get(t1Id)?.coachName ||
+                '',
+              team2Name:
+                rrRegMap.get(t2Id)?.club?.name ||
+                rrRegMap.get(t2Id)?.coachName ||
+                '',
+            });
+          }
+        }
+      }
+
+      (bracketData as any).matches = groupPhaseMatches;
     }
 
     // Save bracket data - store per age group if ageGroupId is provided

--- a/src/modules/groups/services/bracket-generator.service.ts
+++ b/src/modules/groups/services/bracket-generator.service.ts
@@ -25,18 +25,20 @@ export interface Match {
   isManualOverride?: boolean; // Flag indicating manual advancement override
   scheduledAt?: Date;
   courtNumber?: number; // BE-07: court/field assignment
+  fieldName?: string; // football field name
   locationId?: string;
   status: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED';
   nextMatchId?: string;
   loserNextMatchId?: string; // For double elimination
   autoAdvance?: boolean; // BYE match — top-seeded team advances automatically (BE-SE-01)
+  groupLetter?: string; // group phase tag (GROUPS_PLUS_KNOCKOUT / GROUPS_ONLY)
 }
 
 export interface PlayoffRound {
   roundNumber: number;
   roundName: string;
   matches: Match[];
-  bracket?: 'winners' | 'losers' | 'grand_final'; // DE bracket column (BE-DE-01)
+  bracket?: 'winners' | 'losers' | 'grand_final' | 'third_place'; // bracket column tag
 }
 
 export interface BracketData {
@@ -199,6 +201,7 @@ export class BracketGeneratorService {
             status: 'PENDING',
           },
         ],
+        bracket: 'third_place',
       };
       playoffRounds.push(thirdPlaceRound);
     }
@@ -334,6 +337,48 @@ export class BracketGeneratorService {
         const targetIdx = Math.floor(i / factor);
         if (lrRound.matches[targetIdx]) {
           match.loserNextMatchId = lrRound.matches[targetIdx].id;
+        }
+      });
+    }
+
+    // ── Wire nextMatchId for winner advancement within each bracket ─────────
+    // Winners bracket: each round feeds the next (halving each time)
+    const winnersRounds = playoffRounds.filter((r) => r.bracket === 'winners');
+    const losersRounds  = playoffRounds.filter((r) => r.bracket === 'losers');
+    const grandFinalRound = playoffRounds.find((r) => r.bracket === 'grand_final');
+
+    // Within WR: match[i] → match[⌊i/2⌋] in next WR round; WR final → Grand Final
+    for (let i = 0; i < winnersRounds.length; i++) {
+      const cur  = winnersRounds[i];
+      const next = winnersRounds[i + 1] ?? null;
+      const gfTarget = i === winnersRounds.length - 1 ? grandFinalRound : null;
+      cur.matches.forEach((match, mi) => {
+        if (next) {
+          const targetIdx = Math.floor(mi / 2);
+          if (next.matches[targetIdx]) {
+            match.nextMatchId = next.matches[targetIdx].id;
+          }
+        } else if (gfTarget?.matches[0]) {
+          match.nextMatchId = gfTarget.matches[0].id;
+        }
+      });
+    }
+
+    // Within LR: same count → 1:1; fewer → halving; LR final → Grand Final
+    for (let i = 0; i < losersRounds.length; i++) {
+      const cur  = losersRounds[i];
+      const next = losersRounds[i + 1] ?? null;
+      const gfTarget = i === losersRounds.length - 1 ? grandFinalRound : null;
+      cur.matches.forEach((match, mi) => {
+        if (next) {
+          const targetIdx = next.matches.length < cur.matches.length
+            ? Math.floor(mi / 2)
+            : mi;
+          if (next.matches[targetIdx]) {
+            match.nextMatchId = next.matches[targetIdx].id;
+          }
+        } else if (gfTarget?.matches[0]) {
+          match.nextMatchId = gfTarget.matches[0].id;
         }
       });
     }

--- a/src/modules/groups/services/pot-draw.service.ts
+++ b/src/modules/groups/services/pot-draw.service.ts
@@ -114,8 +114,15 @@ export class PotDrawService {
 
     const pots = await queryBuilder.getMany();
 
+    // Dynamically determine max pot number from actual assignments
     const potMap = new Map<number, TournamentPot[]>();
-    for (let i = 1; i <= 4; i++) {
+    let maxPot = 0;
+    for (const p of pots) {
+      if (p.potNumber > maxPot) maxPot = p.potNumber;
+    }
+    // Always include at least pot 1
+    if (maxPot < 1) maxPot = 1;
+    for (let i = 1; i <= maxPot; i++) {
       potMap.set(i, pots.filter((p) => p.potNumber === i));
     }
 
@@ -185,6 +192,11 @@ export class PotDrawService {
       );
     }
 
+    const baseTeamsPerGroup = Math.floor(totalTeams / dto.numberOfGroups);
+    const remainder = totalTeams % dto.numberOfGroups;
+    const numFullPots = baseTeamsPerGroup;              // full pots, each with numberOfGroups teams
+    const expectedTeamsPerFullPot = dto.numberOfGroups; // teams_per_pot = num_groups
+
     // Get pot assignments (filtered by age group if specified)
     const potAssignments = await this.getPotAssignments(tournamentId, dto.ageGroupId);
 
@@ -200,6 +212,35 @@ export class PotDrawService {
       );
     }
 
+    // Validate pot structure:
+    //   - Pots 1..numFullPots: each with exactly numberOfGroups teams
+    //   - If remainder > 0: pot numFullPots+1 with exactly `remainder` teams
+    for (let i = 1; i <= numFullPots; i++) {
+      const potTeams = potAssignments.get(i) || [];
+      if (potTeams.length !== expectedTeamsPerFullPot) {
+        throw new BadRequestException(
+          `Pot ${i} has ${potTeams.length} teams, but must have exactly ${expectedTeamsPerFullPot} ` +
+          `(= number of groups). Each full pot must contain exactly as many teams as there are groups.`,
+        );
+      }
+    }
+
+    if (remainder > 0) {
+      const remainderPotNum = numFullPots + 1;
+      const remainderTeams = potAssignments.get(remainderPotNum) || [];
+      if (remainderTeams.length !== remainder) {
+        throw new BadRequestException(
+          `Remainder pot (Pot ${remainderPotNum}) has ${remainderTeams.length} teams, ` +
+          `but must have exactly ${remainder} teams (the remainder of ${totalTeams} ÷ ${dto.numberOfGroups}).`,
+        );
+      }
+    }
+
+    const nonEmptyPots: number[] = [];
+    for (const [potNum, teams] of potAssignments.entries()) {
+      if (teams.length > 0) nonEmptyPots.push(potNum);
+    }
+
     // Initialize groups with their letters
     const groupLetters = this.getGroupLetters(dto.numberOfGroups);
     const groups: { letter: string; teams: string[] }[] = groupLetters.map(
@@ -209,56 +250,39 @@ export class PotDrawService {
       }),
     );
 
-    // Execute pot-based distribution with snake draft pattern
+    // Sort pot numbers so we process Pot 1 first, Pot 2 second, etc.
+    nonEmptyPots.sort((a, b) => a - b);
+
     // Shuffle within each pot for randomness
     const shuffledPots = new Map<number, TournamentPot[]>();
-    for (let potNum = 1; potNum <= 4; potNum++) {
+    for (const potNum of nonEmptyPots) {
       const potTeams = potAssignments.get(potNum) || [];
-      if (potTeams.length > 0) {
-        shuffledPots.set(
-          potNum,
-          this.seededShuffle([...potTeams], tournamentId + potNum),
-        );
+      shuffledPots.set(
+        potNum,
+        this.seededShuffle([...potTeams], tournamentId + potNum),
+      );
+    }
+
+    // Distribution:
+    //   Full pots (1..numFullPots): each group receives exactly 1 team per pot.
+    //   Remainder pot (numFullPots+1, if exists): its teams go to randomly
+    //   chosen groups, so `remainder` groups get one extra team.
+    for (let potNum = 1; potNum <= numFullPots; potNum++) {
+      const potTeams = shuffledPots.get(potNum)!;
+      for (let g = 0; g < dto.numberOfGroups; g++) {
+        groups[g].teams.push(potTeams[g].registrationId);
       }
     }
 
-    // Distribute teams using snake draft pattern
-    // This ensures balanced distribution even with uneven pot sizes
-    let groupIdx = 0;
-    let direction = 1; // 1 for forward, -1 for backward (snake pattern)
-    let teamIndex = new Map<number, number>(); // Track which team in each pot
-    
-    // Initialize team indices
-    for (const potNum of [1, 2, 3, 4]) {
-      teamIndex.set(potNum, 0);
-    }
-
-    // Continue until all teams are assigned
-    let assignedTeams = 0;
-    while (assignedTeams < totalTeams) {
-      // Try to assign one team from each pot to the current group
-      for (const potNum of [1, 2, 3, 4]) {
-        const potTeams = shuffledPots.get(potNum);
-        const idx = teamIndex.get(potNum);
-        
-        if (potTeams && idx !== undefined && idx < potTeams.length && groupIdx < dto.numberOfGroups) {
-          const team = potTeams[idx];
-          groups[groupIdx].teams.push(team.registrationId);
-          teamIndex.set(potNum, idx + 1);
-          assignedTeams++;
-          
-          // Move to next group
-          groupIdx += direction;
-          
-          // Handle snake pattern (reverse direction at ends)
-          if (groupIdx >= dto.numberOfGroups) {
-            groupIdx = dto.numberOfGroups - 1;
-            direction = -1;
-          } else if (groupIdx < 0) {
-            groupIdx = 0;
-            direction = 1;
-          }
-        }
+    // Distribute remainder pot teams to randomly selected groups
+    if (remainder > 0) {
+      const remainderPotNum = numFullPots + 1;
+      const remainderTeams = shuffledPots.get(remainderPotNum)!;
+      // Randomly pick which groups get the extra team
+      const groupIndices = Array.from({ length: dto.numberOfGroups }, (_, i) => i);
+      const shuffledGroupIndices = this.seededShuffle(groupIndices, tournamentId + 'remainder');
+      for (let i = 0; i < remainder; i++) {
+        groups[shuffledGroupIndices[i]].teams.push(remainderTeams[i].registrationId);
       }
     }
 


### PR DESCRIPTION
## Summary

Refactors the pot-based group draw to support any number of groups — including configurations where the total number of teams is **not evenly divisible** by the number of groups.

## Changes

### `pot-draw.service.ts`
- **Removed** strict `totalTeams % numberOfGroups !== 0` validation
- **Supports remainder pot**: `numFullPots = floor(totalTeams / numberOfGroups)`, excess teams go into pot `N+1`
- **Validation**: full pots must have exactly `numberOfGroups` teams; remainder pot must have exactly `remainder` teams
- **Distribution**: full pots assign 1 team per group (balanced seeding); remainder pot teams are distributed to randomly chosen groups
- **Dynamic `getPotAssignments`**: no longer hardcodes 4 pots — iterates actual pot keys from DB

### `pot.dto.ts`
- `@Max(4)` → `@Max(32)` on `potNumber` and `numberOfGroups` to support dynamic configurations

### `groups.controller.ts`
- `getPotAssignments` endpoint returns dynamic pot list (sorted pot keys from DB)

### `groups.service.ts` / `bracket-generator.service.ts`
- Related group service updates to support new draw flow

## Behaviour

| Teams | Groups | Full Pots | Remainder |
|-------|--------|-----------|-----------|
| 16 | 4 | 4 × 4 | none |
| 8 | 3 | 2 × 3 | 1 pot × 2 teams |
| 8 | 5 | 1 × 5 | 1 pot × 3 teams |

During draw, remainder teams are assigned to `remainder` randomly-chosen groups — those groups receive one extra team.