### PR TITLE
feat(groups): tiebreak system, adjacent-group seeding & bracket reset

### DIFF
--- a/src/modules/groups/entities/group.entity.ts
+++ b/src/modules/groups/entities/group.entity.ts
@@ -33,6 +33,15 @@ export class Group {
   @Column({ name: 'group_order', default: 0 })
   groupOrder: number;
 
+  /**
+   * Manual tiebreak order: an ordered list of teamIds.
+   * When two or more teams are exactly tied (pts, GD, GF), position is
+   * resolved by the index of the teamId in this array (lower index = higher rank).
+   * Set by the organizer via the tiebreak endpoint after all group matches complete.
+   */
+  @Column({ name: 'tie_break_order', type: 'json', nullable: true })
+  tieBreakOrder: string[] | null;
+
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 }

--- a/src/modules/groups/groups.controller.ts
+++ b/src/modules/groups/groups.controller.ts
@@ -342,4 +342,26 @@ export class GroupsController {
     await this.potDrawService.clearPotAssignments(tournamentId, user.sub, user.role, ageGroupId);
     return { message: 'Pot assignments cleared' };
   }
+
+  @Patch('groups/:groupId/tiebreak')
+  @ApiOperation({ summary: 'Set manual tiebreak order for a group (organizer only)' })
+  @ApiResponse({ status: 200, description: 'Tiebreak order saved; bracket re-seeded when all group matches are done' })
+  @ApiResponse({ status: 403, description: 'Not authorized' })
+  @ApiResponse({ status: 404, description: 'Group not found' })
+  setGroupTiebreak(
+    @Param('tournamentId', ParseUUIDPipe) tournamentId: string,
+    @Param('groupId') groupId: string,
+    @Body() dto: { order: string[] },
+    @CurrentUser() user: JwtPayload,
+    @Query('ageGroupId') ageGroupId?: string,
+  ) {
+    return this.groupsService.setGroupTiebreak(
+      tournamentId,
+      groupId,
+      dto.order,
+      user.sub,
+      user.role,
+      ageGroupId,
+    );
+  }
 }

--- a/src/modules/groups/groups.service.ts
+++ b/src/modules/groups/groups.service.ts
@@ -679,6 +679,7 @@ export class GroupsService {
     bracketType?: string;
     playoffRounds?: any[];
     teams: { id: string; name: string; clubName?: string }[];
+    advancingTeamsPerGroup?: number;
   }> {
     const tournament = await this.tournamentsRepository.findOne({
       where: { id: tournamentId },
@@ -740,6 +741,7 @@ export class GroupsService {
       bracketType: ageBracket.type,
       playoffRounds: ageBracket.playoffRounds,
       teams,
+      advancingTeamsPerGroup: (ageBracket as any).advancingTeamsPerGroup ?? undefined,
     };
   }
 
@@ -1007,6 +1009,7 @@ export class GroupsService {
           const standings = this.bracketGeneratorService.calculateGroupStandings(
             group.teams,
             gMatches,
+            group.tieBreakOrder,
           );
           perGroupStandings.set(group.groupLetter, standings);
         }
@@ -1026,6 +1029,31 @@ export class GroupsService {
           if (m.team1Id) m.team1Name = nameMap.get(m.team1Id) || m.team1Name || '';
           if (m.team2Id) m.team2Name = nameMap.get(m.team2Id) || m.team2Name || '';
         }
+
+        // Reset all playoff rounds to a clean state so the knockout phase
+        // starts fresh with the correctly seeded teams from group standings.
+        // First round: keep seeded teams but clear any prior results/manual
+        // overrides from the initial (draw-position-based) placeholder seeding.
+        // Later rounds: remove any team data propagated from the wrong seeding.
+        bracketData.playoffRounds.forEach((round, roundIndex) => {
+          (round.matches as Match[]).forEach((m) => {
+            m.status = 'PENDING';
+            m.team1Score = undefined;
+            m.team2Score = undefined;
+            m.winnerId = undefined;
+            m.loserId = undefined;
+            m.manualWinnerId = undefined;
+            m.isManualOverride = false;
+            if (roundIndex > 0) {
+              // Subsequent rounds: also clear team slots (will be filled when SF
+              // winners advance via the normal score-submission propagation)
+              m.team1Id = undefined;
+              m.team1Name = undefined;
+              m.team2Id = undefined;
+              m.team2Name = undefined;
+            }
+          });
+        });
 
         bracketUpdated = true;
       }
@@ -1488,5 +1516,121 @@ export class GroupsService {
     } catch {
       // Non-critical — silently skip if calculation fails
     }
+  }
+
+  /**
+   * Set the manual tiebreak order for a group.
+   * When two or more teams are exactly equal (pts / GD / GF), the team
+   * appearing earlier in `order` gets the better rank.
+   * Re-triggers bracket seeding if all group matches are already done.
+   */
+  async setGroupTiebreak(
+    tournamentId: string,
+    groupId: string,
+    order: string[],
+    userId: string,
+    userRole: string,
+    ageGroupId?: string,
+  ): Promise<{ success: boolean; bracketUpdated: boolean }> {
+    const tournament = await this.tournamentsRepository.findOne({
+      where: { id: tournamentId },
+    });
+    if (!tournament) throw new NotFoundException('Tournament not found');
+    if (tournament.organizerId !== userId && userRole !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'Only the tournament organizer can set tiebreak order',
+      );
+    }
+
+    const group = await this.groupsRepository.findOne({
+      where: { id: groupId, tournamentId },
+    });
+    if (!group) throw new NotFoundException('Group not found');
+
+    await this.groupsRepository.update(groupId, { tieBreakOrder: order });
+    group.tieBreakOrder = order;
+
+    let bracketUpdated = false;
+
+    if (!tournament.bracketData) return { success: true, bracketUpdated };
+
+    const fullBracketData = tournament.bracketData as any;
+    const bracketData =
+      this.getBracketForAgeGroup(fullBracketData, ageGroupId) || fullBracketData;
+
+    if (!bracketData.matches || !bracketData.playoffRounds?.length) {
+      return { success: true, bracketUpdated };
+    }
+
+    const groupPhaseMatches = bracketData.matches as Match[];
+    const allGroupDone =
+      groupPhaseMatches.length > 0 &&
+      groupPhaseMatches.every((m) => m.status === 'COMPLETED');
+
+    if (!allGroupDone) return { success: true, bracketUpdated };
+
+    // All group matches are done — re-seed with updated tiebreak
+    const groups = await this.groupsRepository.find({
+      where: { tournamentId },
+      order: { groupLetter: 'ASC' },
+    });
+
+    const nameMap = new Map<string, string>();
+    for (const m of groupPhaseMatches) {
+      if (m.team1Id && m.team1Name) nameMap.set(m.team1Id, m.team1Name);
+      if (m.team2Id && m.team2Name) nameMap.set(m.team2Id, m.team2Name);
+    }
+
+    const perGroupStandings = new Map<string, GroupStanding[]>();
+    for (const g of groups) {
+      const gMatches = groupPhaseMatches.filter(
+        (m) => m.groupLetter === g.groupLetter,
+      );
+      const standings = this.bracketGeneratorService.calculateGroupStandings(
+        g.teams,
+        gMatches,
+        g.tieBreakOrder,
+      );
+      perGroupStandings.set(g.groupLetter, standings);
+    }
+
+    const advancingPerGroup =
+      (bracketData as any).advancingTeamsPerGroup ?? 2;
+    this.bracketGeneratorService.seedTeamsIntoBracket(
+      perGroupStandings,
+      advancingPerGroup,
+      bracketData,
+    );
+
+    const firstRound = bracketData.playoffRounds[0];
+    for (const m of firstRound.matches) {
+      if (m.team1Id) m.team1Name = nameMap.get(m.team1Id) || m.team1Name || '';
+      if (m.team2Id) m.team2Name = nameMap.get(m.team2Id) || m.team2Name || '';
+    }
+
+    bracketData.playoffRounds.forEach((round: any, roundIndex: number) => {
+      (round.matches as Match[]).forEach((m) => {
+        m.status = 'PENDING';
+        m.team1Score = undefined;
+        m.team2Score = undefined;
+        m.winnerId = undefined;
+        m.loserId = undefined;
+        m.manualWinnerId = undefined;
+        m.isManualOverride = false;
+        if (roundIndex > 0) {
+          m.team1Id = undefined;
+          m.team1Name = undefined;
+          m.team2Id = undefined;
+          m.team2Name = undefined;
+        }
+      });
+    });
+
+    await this.tournamentsRepository.update(tournamentId, {
+      bracketData: fullBracketData,
+    });
+    bracketUpdated = true;
+
+    return { success: true, bracketUpdated };
   }
 }

--- a/src/modules/groups/services/bracket-generator.service.ts
+++ b/src/modules/groups/services/bracket-generator.service.ts
@@ -637,11 +637,14 @@ export class BracketGeneratorService {
   }
 
   /**
-   * Calculate group standings from match results
+   * Calculate group standings from match results.
+   * @param tieBreakOrder optional ordered list of teamIds — when two teams are
+   *   perfectly equal on pts/GD/GF the one appearing earlier in this array wins.
    */
   calculateGroupStandings(
     groupTeamIds: string[],
     matches: Match[],
+    tieBreakOrder?: string[] | null,
   ): GroupStanding[] {
     const standings: Map<string, GroupStanding> = new Map();
 
@@ -700,7 +703,7 @@ export class BracketGeneratorService {
         team2.goalDifference = team2.goalsFor - team2.goalsAgainst;
       });
 
-    // Sort standings
+    // Sort standings: Pts → GD → GF → tieBreakOrder → draw position
     const sortedStandings = Array.from(standings.values()).sort((a, b) => {
       // Points
       if (b.points !== a.points) return b.points - a.points;
@@ -709,7 +712,15 @@ export class BracketGeneratorService {
         return b.goalDifference - a.goalDifference;
       // Goals for
       if (b.goalsFor !== a.goalsFor) return b.goalsFor - a.goalsFor;
-      // Default
+      // Manual tiebreak order set by organizer
+      if (tieBreakOrder && tieBreakOrder.length > 0) {
+        const ia = tieBreakOrder.indexOf(a.teamId);
+        const ib = tieBreakOrder.indexOf(b.teamId);
+        if (ia !== -1 && ib !== -1) return ia - ib;
+        if (ia !== -1) return -1;
+        if (ib !== -1) return 1;
+      }
+      // Default: preserve original draw order (stable)
       return 0;
     });
 
@@ -722,13 +733,14 @@ export class BracketGeneratorService {
   }
 
   /**
-   * Seed advancing teams into the knockout bracket using cross-group interleaving (PM-02).
+   * Seed advancing teams into the knockout bracket using adjacent-group pairing.
    *
-   * Standard 4-group pattern (works for any even number of groups):
-   *   QF1: 1A v 2B     QF2: 1C v 2D
-   *   QF3: 2A v 1B     QF4: 2C v 1D
+   * Groups are paired in order: (A,B), (C,D), (E,F), ...
+   * Within each pair, same-position teams face each other:
+   *   Match 1: 1A vs 1B   Match 2: 1C vs 1D   (winners of each pair)
+   *   Match 3: 2A vs 2B   Match 4: 2C vs 2D   (runners-up, only if advancingPerGroup >= 2)
    *
-   * This ensures group winners avoid each other until at least the semi-finals.
+   * Total first-round matches = (numGroups / 2) * advancingPerGroup.
    * Falls back to position-based seeding when the group count is odd or < 2.
    */
   seedTeamsIntoBracket(
@@ -739,33 +751,36 @@ export class BracketGeneratorService {
     const groupKeys = Array.from(groupStandings.keys());
     const numGroups = groupKeys.length;
 
-    // Separate winners (pos 1) and runners-up (pos 2) per group
-    const winners: { teamId: string; groupId: string }[] = [];
-    const runnersUp: { teamId: string; groupId: string }[] = [];
+    // Collect advancing teams grouped by their standing position (1-based)
+    const byPosition = new Map<number, { teamId: string; groupId: string }[]>();
 
     groupKeys.forEach((groupId) => {
       const standings = groupStandings.get(groupId) ?? [];
       standings.slice(0, advancingPerGroup).forEach((s) => {
-        if (s.position === 1) winners.push({ teamId: s.teamId, groupId });
-        else runnersUp.push({ teamId: s.teamId, groupId });
+        if (!byPosition.has(s.position)) byPosition.set(s.position, []);
+        byPosition.get(s.position)!.push({ teamId: s.teamId, groupId });
       });
     });
 
-    // Build ordered list of match seeds using cross-group interleaving
+    // Build match seeds: for each position level (1st, 2nd, ...) pair adjacent groups
     const matchSeeds: Array<[string | undefined, string | undefined]> = [];
 
     if (numGroups >= 2 && numGroups % 2 === 0) {
-      // First half: winners[even-idx] vs runnersUp[odd-idx] → 1A v 2B, 1C v 2D ...
-      for (let i = 0; i + 1 < numGroups; i += 2) {
-        matchSeeds.push([winners[i]?.teamId, runnersUp[i + 1]?.teamId]);
-      }
-      // Second half: runnersUp[even-idx] vs winners[odd-idx] → 2A v 1B, 2C v 1D ...
-      for (let i = 0; i + 1 < numGroups; i += 2) {
-        matchSeeds.push([runnersUp[i]?.teamId, winners[i + 1]?.teamId]);
+      // For each position, pair groups (0,1), (2,3), (4,5) ...
+      // 1st pass → 1A vs 1B, 1C vs 1D ...
+      // 2nd pass → 2A vs 2B, 2C vs 2D ... (when advancingPerGroup >= 2)
+      for (let pos = 1; pos <= advancingPerGroup; pos++) {
+        const teamsAtPos = byPosition.get(pos) ?? [];
+        for (let i = 0; i + 1 < teamsAtPos.length; i += 2) {
+          matchSeeds.push([teamsAtPos[i]?.teamId, teamsAtPos[i + 1]?.teamId]);
+        }
       }
     } else {
-      // Fallback: sort all advancing teams by position, seed best vs worst
-      const all = [...winners, ...runnersUp];
+      // Fallback for odd group counts: seed best vs worst across all advancing teams
+      const all: { teamId: string; groupId: string }[] = [];
+      for (let pos = 1; pos <= advancingPerGroup; pos++) {
+        all.push(...(byPosition.get(pos) ?? []));
+      }
       for (let i = 0; i < Math.floor(all.length / 2); i++) {
         matchSeeds.push([all[i]?.teamId, all[all.length - 1 - i]?.teamId]);
       }


### PR DESCRIPTION
## Summary

Three related improvements to the group stage management system.

### 1. Manual Tiebreak Resolution
When two or more teams finish a group with identical standings (points, goal difference, goals scored), the organizer can now manually designate the group winner.

**Changes:**
- `group.entity.ts` — new `tieBreakOrder: string[] | null` column (`json`, nullable) stores the ordered list of teamIds as chosen by the organizer
- `groups.controller.ts` — new `PATCH /groups/:groupId/tiebreak` endpoint (`setGroupTiebreak`)
- `groups.service.ts` — `setGroupTiebreak()` method; `calculateGroupStandings` (inside bracket-generator) uses `tieBreakOrder` as 4th sort criterion after pts → GD → GF

### 2. Adjacent-Group Pairing for Knockout Seeding
Semifinal matchups now use adjacent-group pairing instead of cross-group interleaving:
- **Before:** 1A vs 2B, 1B vs 2A (cross)
- **After:** 1A vs 1B, 1C vs 1D (adjacent)

**Changes:**
- `bracket-generator.service.ts` — `seedTeamsIntoBracket` rewritten to pair winners from adjacent groups (indices 0&1, 2&3, etc.)

### 3. Playoff Round Reset on Group Completion
When all groups are marked done and the bracket is re-seeded, existing playoff round results are now cleared first to prevent stale data.

**Changes:**
- `groups.service.ts` — `allGroupDone` block resets playoff rounds before calling `seedTeamsIntoBracket`; `getMatches` return value includes `advancingTeamsPerGroup`

## Files Changed
| File | Change |
|------|--------|
| `src/modules/groups/entities/group.entity.ts` | Add `tieBreakOrder` column |
| `src/modules/groups/groups.controller.ts` | Add tiebreak endpoint |
| `src/modules/groups/groups.service.ts` | Tiebreak service method, playoff reset, advancingTeamsPerGroup in response |
| `src/modules/groups/services/bracket-generator.service.ts` | Adjacent-group pairing, tieBreakOrder sort criterion |

## Related
- Frontend PR: Sport-Tournaments/sport-tournaments-frontend (same branch name)