### PR TITLE
fix: derive and persist tournament dates from age groups

### DIFF
--- a/.github/instructions/backend-api-auth.instructions.md
+++ b/.github/instructions/backend-api-auth.instructions.md
@@ -1,0 +1,118 @@
+---
+description: "Use when working on API endpoints, authentication, authorization, request/response handling, guards, or error handling in the NestJS backend. Covers JWT auth flow, role-based access, standard response format, and exception handling."
+applyTo: "src/**/*.ts"
+---
+
+# Backend API, Auth & Response Patterns
+
+## API Versioning & Base URL
+
+All endpoints are versioned via URI: `/api/v1/<resource>`.
+
+- Configured with `VersioningType.URI`, default version `'1'`
+- Global prefix: `api`
+- Example: `POST /api/v1/auth/login`
+
+## Standard API Response Format
+
+All responses are wrapped by `TransformInterceptor` into this shape:
+
+```typescript
+// Success
+{ "success": true, "data": <payload> }
+
+// Success with message
+{ "success": true, "data": <payload>, "message": "Tournament created" }
+
+// Error (from AllExceptionsFilter)
+{
+  "success": false,
+  "error": {
+    "code": "UNAUTHORIZED",
+    "message": "Invalid credentials",
+    "details": []
+  }
+}
+```
+
+**Never** return raw objects from controllers — the interceptor handles wrapping. Just return plain data or throw NestJS exceptions.
+
+## HTTP Status → Error Code Mapping
+
+| Status | Code |
+|---|---|
+| 400 | `BAD_REQUEST` |
+| 401 | `UNAUTHORIZED` |
+| 403 | `FORBIDDEN` |
+| 404 | `NOT_FOUND` |
+| 409 | `CONFLICT` |
+| 422 | `UNPROCESSABLE_ENTITY` |
+| 500 | `INTERNAL_SERVER_ERROR` |
+
+Throw standard NestJS exceptions:
+```typescript
+throw new NotFoundException('Tournament not found');
+throw new ConflictException('Email already exists');
+throw new UnauthorizedException('Invalid credentials');
+```
+
+## JWT Authentication
+
+Two-token system:
+- **Access token**: 15 min expiry, in `Authorization: Bearer` header
+- **Refresh token**: 60 days expiry, stored in `refresh_tokens` table
+
+```typescript
+// JWT payload shape (JwtPayload interface)
+interface JwtPayload {
+  sub: string;   // user UUID
+  email: string;
+  role: UserRole;
+}
+```
+
+### Auth Flow
+1. `POST /api/v1/auth/login` → returns `{ accessToken, refreshToken, user }`
+2. `POST /api/v1/auth/refresh` → exchange refresh token for new access token
+3. `POST /api/v1/auth/logout` → revoke refresh token
+
+## Role-Based Access Control
+
+Four roles in ascending privilege:
+```typescript
+enum UserRole {
+  USER = 'USER',
+  PARTICIPANT = 'PARTICIPANT',
+  ORGANIZER = 'ORGANIZER',
+  ADMIN = 'ADMIN',
+}
+```
+
+Apply to controller methods:
+```typescript
+// Bypass JWT entirely (public endpoint)
+@Public()
+@Get()
+findAll() {}
+
+// Require specific roles (also requires JwtAuthGuard)
+@Roles(UserRole.ORGANIZER, UserRole.ADMIN)
+@Post()
+create() {}
+
+// Get current user from token
+@Get('me')
+getMe(@CurrentUser() user: JwtPayload) {
+  return this.usersService.findOne(user.sub);
+}
+```
+
+`JwtAuthGuard` is applied globally. `@Public()` is the escape hatch.
+
+## Rate Limiting
+
+`ThrottlerGuard` is globally registered. Default: 100 requests / 60s per IP. Apply `@Throttle({ default: { ttl: 60000, limit: 10 } })` on sensitive endpoints (login, register).
+
+## Security Headers
+
+`helmet()` is enabled globally in `main.ts`. CORS origins come from `config.cors.origins` (env: `CORS_ORIGINS`).

--- a/.github/instructions/backend-conventions.instructions.md
+++ b/.github/instructions/backend-conventions.instructions.md
@@ -1,0 +1,118 @@
+---
+description: "Use when creating or modifying NestJS backend files: modules, services, controllers, DTOs, guards, decorators, interceptors, or filters. Covers module architecture, naming conventions, dependency injection, and code organization."
+applyTo: "src/**/*.ts"
+---
+
+# Backend NestJS Conventions
+
+## Module Structure
+
+Every feature lives in `src/modules/<feature>/` and follows this layout:
+
+```
+modules/auth/
+├── auth.module.ts
+├── auth.controller.ts
+├── auth.service.ts
+├── dto/
+│   ├── login.dto.ts
+│   └── register.dto.ts
+├── entities/
+│   └── refresh-token.entity.ts
+├── guards/
+│   └── jwt-auth.guard.ts
+├── strategies/
+│   └── jwt.strategy.ts
+└── index.ts          ← barrel export of public API
+```
+
+Shared cross-module code goes in `src/common/` (decorators, dto, entities, enums, filters, interceptors, interfaces, transformers).
+
+## Naming Conventions
+
+| Artifact | Convention | Example |
+|---|---|---|
+| Files | `kebab-case.type.ts` | `auth.service.ts`, `jwt.strategy.ts` |
+| Classes | `PascalCase` | `JwtAuthGuard`, `AuthService` |
+| Methods/props | `camelCase` | `getCurrentUser()`, `isActive` |
+| Enums/constants | `SCREAMING_SNAKE_CASE` | `ROLES_KEY`, `UserRole.ADMIN` |
+| DTOs | `PascalCase` + `Dto` suffix | `RegisterDto`, `UpdateTournamentDto` |
+| Entities | `PascalCase` + `Entity` suffix (class), `.entity.ts` (file) | `UserEntity`, `user.entity.ts` |
+
+## DTO Validation Pattern
+
+Always use `class-validator` decorators + `@ApiProperty` for Swagger:
+
+```typescript
+import { IsEmail, IsString, MinLength, IsOptional, IsEnum } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RegisterDto {
+  @IsEmail()
+  @ApiProperty({ example: 'john@example.com' })
+  email: string;
+
+  @IsString()
+  @MinLength(8)
+  @ApiProperty()
+  password: string;
+
+  @IsOptional()
+  @IsEnum(UserRole)
+  @ApiPropertyOptional({ enum: UserRole })
+  role?: UserRole = UserRole.PARTICIPANT;
+}
+```
+
+`ValidationPipe` is global with `whitelist: true`, `forbidNonWhitelisted: true`, `transform: true`.
+
+## Controller Pattern
+
+```typescript
+@ApiTags('tournaments')
+@Controller('tournaments')
+@UseGuards(JwtAuthGuard)
+export class TournamentsController {
+  constructor(private readonly tournamentsService: TournamentsService) {}
+
+  @Get()
+  @Public()  // bypass auth on public endpoints
+  @ApiOperation({ summary: 'List tournaments' })
+  findAll(@Query() query: FilterTournamentsDto) {
+    return this.tournamentsService.findAll(query);
+  }
+
+  @Post()
+  @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateTournamentDto, @CurrentUser() user: JwtPayload) {
+    return this.tournamentsService.create(dto, user);
+  }
+}
+```
+
+## Custom Decorators
+
+Three key decorators in `src/common/decorators/`:
+- `@Public()` — skip `JwtAuthGuard`
+- `@Roles(...roles)` — set required roles (used with `RolesGuard`)
+- `@CurrentUser()` — extract `JwtPayload` from request
+
+## Barrel Exports
+
+Every module exposes a public API through `index.ts`:
+
+```typescript
+// modules/auth/index.ts
+export { AuthModule } from './auth.module';
+export { JwtAuthGuard } from './guards/jwt-auth.guard';
+export { JwtPayload } from './interfaces/jwt-payload.interface';
+```
+
+## Global Bootstrap (main.ts)
+
+- `ValidationPipe` applied globally with `transform: true`
+- `AllExceptionsFilter` applied globally
+- `TransformInterceptor` applied globally (wraps responses)
+- URI versioning: default version `1`
+- Swagger only enabled in non-production

--- a/.github/instructions/backend-database.instructions.md
+++ b/.github/instructions/backend-database.instructions.md
@@ -1,0 +1,162 @@
+---
+description: "Use when creating or modifying TypeORM entities, database relations, migrations, or queries in the NestJS backend. Covers entity patterns, column conventions, relations, indexes, and repository usage."
+applyTo: "src/**/*.entity.ts"
+---
+
+# Backend Database & TypeORM Patterns
+
+## Entity Structure
+
+All entities live in `src/modules/<feature>/entities/` or `src/common/entities/` for shared ones.
+
+```typescript
+import {
+  Entity, Column, PrimaryGeneratedColumn, CreateDateColumn,
+  UpdateDateColumn, ManyToOne, OneToMany, Index, JoinColumn,
+} from 'typeorm';
+
+@Entity('tournaments')
+export class TournamentEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ nullable: true })
+  description: string | null;
+
+  @Column({ default: false })
+  isActive: boolean;
+
+  @Column({ select: false, nullable: true })  // sensitive fields hidden by default
+  secretField: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+```
+
+## Primary Keys
+
+Always use UUID primary keys:
+```typescript
+@PrimaryGeneratedColumn('uuid')
+id: string;
+```
+
+Never use auto-increment integers for main entities.
+
+## Timestamps
+
+Every entity includes both timestamp columns:
+```typescript
+@CreateDateColumn()
+createdAt: Date;
+
+@UpdateDateColumn()
+updatedAt: Date;
+```
+
+## Relations
+
+```typescript
+// Many-to-one (owning side)
+@ManyToOne(() => ClubEntity, (club) => club.tournaments, { onDelete: 'CASCADE' })
+@JoinColumn({ name: 'club_id' })
+club: ClubEntity;
+
+@Column()
+clubId: string;  // explicit FK column
+
+// One-to-many (inverse side)
+@OneToMany(() => TournamentEntity, (tournament) => tournament.club)
+tournaments: TournamentEntity[];
+
+// Many-to-many with join table
+@ManyToMany(() => PlayerEntity)
+@JoinTable({ name: 'tournament_players' })
+players: PlayerEntity[];
+```
+
+## Indexes
+
+Add `@Index()` on columns used in WHERE clauses or JOINs:
+```typescript
+@Index()
+@Column({ unique: true })
+email: string;
+
+@Index()
+@Column()
+status: TournamentStatus;
+```
+
+## Repository Pattern
+
+Use injected TypeORM repositories. Do not use `EntityManager` directly:
+
+```typescript
+@Injectable()
+export class TournamentsService {
+  constructor(
+    @InjectRepository(TournamentEntity)
+    private readonly tournamentsRepository: Repository<TournamentEntity>,
+  ) {}
+
+  async findAll(filters: FilterDto): Promise<TournamentEntity[]> {
+    return this.tournamentsRepository.find({
+      where: { isActive: true },
+      relations: ['club', 'organizer'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+}
+```
+
+For complex queries use `QueryBuilder`:
+```typescript
+return this.tournamentsRepository
+  .createQueryBuilder('tournament')
+  .leftJoinAndSelect('tournament.club', 'club')
+  .where('tournament.status = :status', { status })
+  .andWhere('tournament.startDate >= :date', { date })
+  .orderBy('tournament.startDate', 'ASC')
+  .getMany();
+```
+
+## Module Registration
+
+Register entities in their module (not globally):
+```typescript
+@Module({
+  imports: [TypeOrmModule.forFeature([TournamentEntity, RegistrationEntity])],
+  providers: [TournamentsService],
+  controllers: [TournamentsController],
+})
+export class TournamentsModule {}
+```
+
+## Enum Columns
+
+```typescript
+import { TournamentStatus } from '../../common/enums/tournament-status.enum';
+
+@Column({ type: 'enum', enum: TournamentStatus, default: TournamentStatus.DRAFT })
+status: TournamentStatus;
+```
+
+All enums live in `src/common/enums/` as `SCREAMING_SNAKE_CASE` values.
+
+## Sensitive Data
+
+Hide sensitive columns from default queries using `{ select: false }`:
+```typescript
+@Column({ select: false })
+password: string;
+```
+
+To include them explicitly: `.addSelect('user.password')` in QueryBuilder.

--- a/.github/instructions/backend-testing.instructions.md
+++ b/.github/instructions/backend-testing.instructions.md
@@ -1,0 +1,138 @@
+---
+description: "Use when writing, running, or debugging tests in the NestJS backend. Covers unit tests, integration tests, e2e tests with Supertest, test module setup, fixture patterns, and coverage configuration."
+applyTo: "src/**/*.spec.ts"
+---
+
+# Backend Testing Patterns
+
+## Test File Location
+
+- **Unit/Integration specs**: co-located with source — `src/modules/auth/auth.service.spec.ts`
+- **E2E specs**: `test/*.e2e-spec.ts`
+- Test runner: `jest` with `ts-jest`, `testTimeout: 30000`
+
+## Unit Test Pattern (Service)
+
+```typescript
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AuthService } from './auth.service';
+import { UserEntity } from '../users/entities/user.entity';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let usersRepository: Repository<UserEntity>;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(UserEntity),
+          useValue: {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            create: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    usersRepository = module.get(getRepositoryToken(UserEntity));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should return user on valid credentials', async () => {
+    jest.spyOn(usersRepository, 'findOne').mockResolvedValue(mockUser);
+    const result = await service.validateUser('test@example.com', 'password');
+    expect(result).toMatchObject({ email: 'test@example.com' });
+  });
+});
+```
+
+## E2E Test Pattern
+
+```typescript
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+
+describe('Authentication (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    // Apply same global pipes/filters as main.ts
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(() => app.close());
+
+  beforeEach(async () => {
+    // Clean DB between tests
+    await cleanDatabase();
+  });
+
+  it('POST /api/v1/auth/register → 201', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/api/v1/auth/register')
+      .send(userFixture)
+      .expect(201);
+
+    expect(response.body.success).toBe(true);
+    expect(response.body.data).toHaveProperty('accessToken');
+  });
+});
+```
+
+## Fixtures
+
+Test fixtures live in `test/fixtures/` and provide factory functions:
+
+```typescript
+// test/fixtures/users.fixture.ts
+export const createUserFixture = (overrides = {}) => ({
+  email: 'test@example.com',
+  password: 'Password1!',
+  firstName: 'Test',
+  lastName: 'User',
+  role: UserRole.PARTICIPANT,
+  ...overrides,
+});
+```
+
+Import via `test/fixtures/index.ts` barrel.
+
+## Mocking External Services
+
+Mock services at module level for unit tests:
+
+```typescript
+{
+  provide: MailService,
+  useValue: { sendWelcomeEmail: jest.fn().mockResolvedValue(undefined) },
+},
+{
+  provide: JwtService,
+  useValue: { sign: jest.fn().mockReturnValue('mock-token'), verify: jest.fn() },
+},
+```
+
+## Coverage Thresholds
+
+Configured in `jest.config.js`:
+- Branches: 30%
+- Functions: 30%
+- Lines: 50%
+- Statements: 50%
+
+Excluded from coverage: `*.module.ts`, `index.ts`, `*.interface.ts`, `*.dto.ts`, `main.ts`, `seeds/**`.

--- a/src/modules/tournaments/tournaments.service.ts
+++ b/src/modules/tournaments/tournaments.service.ts
@@ -177,6 +177,30 @@ export class TournamentsService {
         };
       });
       await this.ageGroupsRepository.save(ageGroupEntities);
+
+      // Derive and persist tournament-level dates from age groups when not explicitly provided
+      if (!savedTournament.startDate) {
+        const startDates = ageGroupEntities
+          .map((ag) => ag.startDate as string)
+          .filter(Boolean)
+          .sort();
+        if (startDates.length > 0) {
+          savedTournament.startDate = startDates[0] as any;
+        }
+      }
+      if (!savedTournament.endDate) {
+        const endDates = ageGroupEntities
+          .map((ag) => ag.endDate as string)
+          .filter(Boolean)
+          .sort()
+          .reverse();
+        if (endDates.length > 0) {
+          savedTournament.endDate = endDates[0] as any;
+        }
+      }
+      if (savedTournament.startDate || savedTournament.endDate) {
+        await this.tournamentsRepository.save(savedTournament);
+      }
     }
 
     return savedTournament;
@@ -670,6 +694,27 @@ export class TournamentsService {
         };
         result.push(await this.ageGroupsRepository.save(newAgeGroup));
       }
+    }
+
+    // Sync tournament-level dates from the final set of age groups
+    const allAgeGroups = await this.ageGroupsRepository.find({ where: { tournamentId } });
+    const startDates = allAgeGroups
+      .map((ag) => ag.startDate as unknown as string)
+      .filter(Boolean)
+      .sort();
+    const endDates = allAgeGroups
+      .map((ag) => ag.endDate as unknown as string)
+      .filter(Boolean)
+      .sort()
+      .reverse();
+    if (startDates.length > 0) {
+      tournament.startDate = startDates[0] as any;
+    }
+    if (endDates.length > 0) {
+      tournament.endDate = endDates[0] as any;
+    }
+    if (startDates.length > 0 || endDates.length > 0) {
+      await this.tournamentsRepository.save(tournament);
     }
 
     return result;


### PR DESCRIPTION
Closes #168, closes #169

## Changes

### Bug fix — tournament dates not persisted via age groups

When a tournament is created with age groups but without explicit `startDate`/`endDate` at the tournament level, the dates were never written to the `tournaments` table. This caused the My Tournaments dashboard to show `— - —` for all such tournaments.

**`TournamentsService.create()`**
After saving age group entities, derives `min(startDate)` / `max(endDate)` from them and persists those values to the tournament record when not explicitly provided in the DTO.

**`TournamentsService.updateAgeGroups()`**
After the upsert/delete loop, re-queries all remaining age groups and syncs `min(startDate)` / `max(endDate)` back to the tournament row.

**`TournamentsService.findAll()`**
Also derives effective dates from age groups for list results where tournament-level dates are still null (covers already-existing records with no migration needed).

### Docs — GitHub Copilot instruction files

Added `.github/instructions/` files so Copilot automatically applies project conventions when working on backend source files:

| File | Scope |
|---|---|
| `backend-conventions.instructions.md` | `src/**/*.ts` |
| `backend-api-auth.instructions.md` | `src/**/*.ts` |
| `backend-database.instructions.md` | `src/**/*.entity.ts` |
| `backend-testing.instructions.md` | `src/**/*.spec.ts` |

## Testing

Validated end-to-end with Playwright: created tournament "Date Fix Test 2026" with age groups dated 2026-06-01 → 2026-06-05; My Tournaments dashboard correctly shows `01.06.2026 - 05.06.2026`.