### PR TITLE
feat: per-age-group registration toggle

### DIFF
--- a/src/modules/registrations/registrations.service.ts
+++ b/src/modules/registrations/registrations.service.ts
@@ -151,6 +151,10 @@ export class RegistrationsService {
         throw new BadRequestException('Invalid age group selection');
       }
 
+      if (selectedAgeGroup.isRegistrationClosed) {
+        throw new BadRequestException('Registrations are closed for this age group');
+      }
+
       const ageGroupMaxTeams =
         selectedAgeGroup.maxTeams ||
         selectedAgeGroup.teamCount ||

--- a/src/modules/tournaments/dto/tournament.dto.ts
+++ b/src/modules/tournaments/dto/tournament.dto.ts
@@ -372,6 +372,11 @@ export class UpdateAgeGroupDto {
   @IsString()
   @MaxLength(2000)
   notes?: string;
+
+  @ApiPropertyOptional({ description: 'Whether registrations are closed for this age group' })
+  @IsOptional()
+  @IsBoolean()
+  isRegistrationClosed?: boolean;
 }
 
 export class UpdateAgeGroupsDto {

--- a/src/modules/tournaments/entities/tournament-age-group.entity.ts
+++ b/src/modules/tournaments/entities/tournament-age-group.entity.ts
@@ -139,6 +139,10 @@ export class TournamentAgeGroup {
   @Column({ name: 'half_duration_minutes', nullable: true })
   halfDurationMinutes?: number;
 
+  // Registration closed flag for this age group
+  @Column({ name: 'is_registration_closed', default: false })
+  isRegistrationClosed: boolean;
+
   // Draw completed flag for this age group
   @Column({ name: 'draw_completed', default: false })
   drawCompleted: boolean;

--- a/src/modules/tournaments/tournaments.controller.ts
+++ b/src/modules/tournaments/tournaments.controller.ts
@@ -32,6 +32,14 @@ import {
   RegenerateInvitationCodeDto,
   UpdateAgeGroupsDto,
 } from './dto';
+import { IsBoolean } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+class SetAgeGroupRegistrationClosedDto {
+  @ApiProperty({ description: 'Whether registrations are closed for this age group' })
+  @IsBoolean()
+  isRegistrationClosed: boolean;
+}
 import { JwtAuthGuard, RolesGuard } from '../auth/guards';
 import { Roles, CurrentUser, Public } from '../../common/decorators';
 import { UserRole } from '../../common/enums';
@@ -165,6 +173,32 @@ export class TournamentsController {
       user.sub,
       user.role,
       updateAgeGroupsDto.ageGroups,
+    );
+  }
+
+  @Patch(':id/age-groups/:ageGroupId/registration-status')
+  @Roles(
+    UserRole.ORGANIZER,
+    UserRole.PARTICIPANT,
+    UserRole.USER,
+    UserRole.ADMIN,
+  )
+  @ApiOperation({ summary: 'Open or close registrations for a specific age group' })
+  @ApiResponse({ status: 200, description: 'Age group registration status updated' })
+  @ApiResponse({ status: 403, description: 'Not allowed to update this tournament' })
+  @ApiResponse({ status: 404, description: 'Tournament or age group not found' })
+  setAgeGroupRegistrationClosed(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('ageGroupId', ParseUUIDPipe) ageGroupId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: SetAgeGroupRegistrationClosedDto,
+  ) {
+    return this.tournamentsService.setAgeGroupRegistrationClosed(
+      id,
+      ageGroupId,
+      dto.isRegistrationClosed,
+      user.sub,
+      user.role,
     );
   }
 

--- a/src/modules/tournaments/tournaments.service.ts
+++ b/src/modules/tournaments/tournaments.service.ts
@@ -839,6 +839,33 @@ export class TournamentsService {
     await this.tournamentsRepository.remove(tournament);
   }
 
+  async setAgeGroupRegistrationClosed(
+    tournamentId: string,
+    ageGroupId: string,
+    isRegistrationClosed: boolean,
+    userId: string,
+    userRole: string,
+  ): Promise<TournamentAgeGroup> {
+    const tournament = await this.findByIdOrFail(tournamentId);
+
+    if (tournament.organizerId !== userId && userRole !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'You are not allowed to update this tournament',
+      );
+    }
+
+    const ageGroup = await this.ageGroupsRepository.findOne({
+      where: { id: ageGroupId, tournamentId },
+    });
+
+    if (!ageGroup) {
+      throw new NotFoundException('Age group not found');
+    }
+
+    ageGroup.isRegistrationClosed = isRegistrationClosed;
+    return this.ageGroupsRepository.save(ageGroup);
+  }
+
   async incrementRegulationsDownload(id: string): Promise<void> {
     await this.tournamentsRepository.increment(
       { id },


### PR DESCRIPTION
Closes #171

## Changes

- `TournamentAgeGroup` entity: new `isRegistrationClosed` boolean column (`is_registration_closed`, default `false`) — auto-created by TypeORM schema sync
- `UpdateAgeGroupDto`: added optional `isRegistrationClosed?: boolean`
- `TournamentsController`: new `SetAgeGroupRegistrationClosedDto` class + `PATCH /:id/age-groups/:ageGroupId/registration-status` endpoint
- `TournamentsService`: new `setAgeGroupRegistrationClosed()` method with organizer/admin authorization
- `RegistrationsService`: checks age-group-level `isRegistrationClosed` before accepting a new registration

## API Endpoint

```
PATCH /api/v1/tournaments/:id/age-groups/:ageGroupId/registration-status
Body: { "isRegistrationClosed": boolean }
```

## Testing

Tested on live instance — U12 closed independently while U9 remained open; registration attempts to closed age group return 400.