### PR TITLE
feat: Add timing configuration fields to TournamentAgeGroup entity an…

### DIFF
--- a/src/modules/tournaments/dto/tournament.dto.ts
+++ b/src/modules/tournaments/dto/tournament.dto.ts
@@ -220,6 +220,28 @@ export class CreateAgeGroupDto {
   halfDurationMinutes?: number;
 
   @ApiPropertyOptional({
+    example: 5,
+    description: 'Pause between halves in minutes (used to auto-calculate match end time)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(60)
+  halfTimePauseMinutes?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: 'Pause between consecutive matches in minutes (used to auto-schedule sequential matches)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(120)
+  pauseBetweenMatchesMinutes?: number;
+
+  @ApiPropertyOptional({
     example: 'Special rules: no sliding tackles',
     description: 'Optional notes or comments for this age category',
   })
@@ -363,6 +385,28 @@ export class UpdateAgeGroupDto {
   @Min(1)
   @Max(120)
   halfDurationMinutes?: number;
+
+  @ApiPropertyOptional({
+    example: 5,
+    description: 'Pause between halves in minutes (used to auto-calculate match end time)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(60)
+  halfTimePauseMinutes?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: 'Pause between consecutive matches in minutes (used to auto-schedule sequential matches)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  @Max(120)
+  pauseBetweenMatchesMinutes?: number;
 
   @ApiPropertyOptional({
     example: 'Special rules: no sliding tackles',

--- a/src/modules/tournaments/entities/tournament-age-group.entity.ts
+++ b/src/modules/tournaments/entities/tournament-age-group.entity.ts
@@ -139,6 +139,14 @@ export class TournamentAgeGroup {
   @Column({ name: 'half_duration_minutes', nullable: true })
   halfDurationMinutes?: number;
 
+  // Pause between halves (minutes), used to auto-calculate match end time
+  @Column({ name: 'half_time_pause_minutes', nullable: true })
+  halfTimePauseMinutes?: number;
+
+  // Pause between consecutive matches (minutes), used to auto-schedule sequential matches
+  @Column({ name: 'pause_between_matches_minutes', nullable: true })
+  pauseBetweenMatchesMinutes?: number;
+
   // Registration closed flag for this age group
   @Column({ name: 'is_registration_closed', default: false })
   isRegistrationClosed: boolean;

--- a/src/modules/tournaments/tournaments.service.ts
+++ b/src/modules/tournaments/tournaments.service.ts
@@ -616,7 +616,7 @@ export class TournamentsService {
     tournamentId: string,
     userId: string,
     userRole: string,
-    ageGroups: { id?: string; birthYear: number; displayLabel?: string; level?: string; format?: string; gameSystem?: string; teamCount?: number; minTeams?: number; numberOfMatches?: number; matchPeriodType?: 'ONE_HALF' | 'TWO_HALVES'; halfDurationMinutes?: number; startDate?: string; endDate?: string; locationId?: string; locationAddress?: string; participationFee?: number; groupsCount?: number; fieldsCount?: number; teamsPerGroup?: number; qualifyingTeamsPerGroup?: number }[],
+    ageGroups: { id?: string; birthYear: number; displayLabel?: string; level?: string; format?: string; gameSystem?: string; teamCount?: number; minTeams?: number; numberOfMatches?: number; matchPeriodType?: 'ONE_HALF' | 'TWO_HALVES'; halfDurationMinutes?: number; halfTimePauseMinutes?: number; pauseBetweenMatchesMinutes?: number; startDate?: string; endDate?: string; locationId?: string; locationAddress?: string; participationFee?: number; groupsCount?: number; fieldsCount?: number; teamsPerGroup?: number; qualifyingTeamsPerGroup?: number }[],
   ): Promise<TournamentAgeGroup[]> {
     const tournament = await this.findByIdOrFail(tournamentId);
 


### PR DESCRIPTION
…d DTO  - Add fields_count, match_period_type, half_duration_minutes,   half_time_pause_minutes, pause_between_matches_minutes columns   to tournament_age_groups table - Add optional DTO fields with validation decorators - Persist timing fields in updateAgeGroups() service method - Enables Auto Schedule feature for all bracket types (SE, DE, RR, LEAGUE, GPK)  Closes #173