### PR TITLE
Fix boolean query parameter parsing for tournament filters

### DIFF
--- a/src/modules/tournaments/dto/tournament.dto.ts
+++ b/src/modules/tournaments/dto/tournament.dto.ts
@@ -18,7 +18,33 @@ import {
   Matches,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { Type, Transform } from 'class-transformer';
+
+/**
+ * Coerce common query-string representations of a boolean into a real boolean.
+ * Returns undefined when the value is missing so `@IsOptional()` works.
+ * Avoids the JS pitfall `Boolean('false') === true`.
+ */
+const toOptionalBoolean = ({
+  obj,
+  key,
+}: {
+  obj: Record<string, unknown>;
+  key: string;
+}): boolean | undefined => {
+  // Read from `obj` (the raw input) instead of `value` to bypass
+  // class-transformer's `enableImplicitConversion`, which would otherwise
+  // turn the string 'false' into Boolean('false') === true before we run.
+  const raw = obj?.[key];
+  if (raw === undefined || raw === null || raw === '') return undefined;
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'string') {
+    const v = raw.trim().toLowerCase();
+    if (v === 'true' || v === '1') return true;
+    if (v === 'false' || v === '0') return false;
+  }
+  return undefined;
+};
 import {
   TournamentStatus,
   TournamentLevel,
@@ -1103,32 +1129,32 @@ export class TournamentFilterDto extends PaginationDto {
 
   @ApiPropertyOptional({ description: 'Sort results by distance from user location', default: false })
   @IsOptional()
+  @Transform(toOptionalBoolean)
   @IsBoolean()
-  @Type(() => Boolean)
   sortByDistance?: boolean;
 
   @ApiPropertyOptional()
   @IsOptional()
+  @Transform(toOptionalBoolean)
   @IsBoolean()
-  @Type(() => Boolean)
   isPremium?: boolean;
 
   @ApiPropertyOptional()
   @IsOptional()
+  @Transform(toOptionalBoolean)
   @IsBoolean()
-  @Type(() => Boolean)
   isFeatured?: boolean;
 
   @ApiPropertyOptional()
   @IsOptional()
+  @Transform(toOptionalBoolean)
   @IsBoolean()
-  @Type(() => Boolean)
   hasAvailableSpots?: boolean;
 
   @ApiPropertyOptional({ description: 'Filter for private/public tournaments' })
   @IsOptional()
+  @Transform(toOptionalBoolean)
   @IsBoolean()
-  @Type(() => Boolean)
   isPrivate?: boolean;
 
   @ApiPropertyOptional()

--- a/src/modules/tournaments/tournaments.service.ts
+++ b/src/modules/tournaments/tournaments.service.ts
@@ -296,7 +296,19 @@ export class TournamentsService {
     }
 
     if (filters?.hasAvailableSpots) {
-      queryBuilder.andWhere('tournament.currentTeams < tournament.maxTeams');
+      // Effective capacity may live on the tournament row OR be derived from age groups
+      // (tournament.max_teams is nullable; many records have it on tournament_age_groups
+      //  via max_teams or team_count). Match if any source shows available spots.
+      queryBuilder.andWhere(
+        `(
+          (tournament.max_teams IS NOT NULL AND tournament.current_teams < tournament.max_teams)
+          OR EXISTS (
+            SELECT 1 FROM tournament_age_groups ag
+            WHERE ag.tournament_id = tournament.id
+              AND ag.current_teams < COALESCE(ag.max_teams, ag.team_count, 0)
+          )
+        )`,
+      );
     }
 
     if (filters?.isPrivate !== undefined) {


### PR DESCRIPTION
## Summary

- Replace `@Type(() => Boolean)` with a custom `@Transform(toOptionalBoolean)` to correctly handle `'false'` string values
- Fix `hasAvailableSpots` query to also check `tournament_age_groups` for available capacity
- Closes #177