### PR TITLE
feat: improve tournament data loading and bracket swaps

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { LocationsModule } from './modules/locations/locations.module';
 import { MailModule } from './modules/mail/mail.module';
 import { TeamsModule } from './modules/teams/teams.module';
 import { PlayersModule } from './modules/players/players.module';
+import { DashboardModule } from './modules/dashboard/dashboard.module';
 
 @Module({
   imports: [
@@ -70,6 +71,7 @@ import { PlayersModule } from './modules/players/players.module';
     LocationsModule,
     TeamsModule,
     PlayersModule,
+    DashboardModule,
   ],
   controllers: [],
   providers: [],

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CurrentUser } from '../../common/decorators';
+import { JwtPayload } from '../../common/interfaces';
+import { JwtAuthGuard } from '../auth/guards';
+import { DashboardService } from './dashboard.service';
+
+@ApiTags('Dashboard')
+@Controller('dashboard')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get('summary')
+  @ApiOperation({ summary: 'Get compact dashboard summary for current user' })
+  @ApiResponse({ status: 200, description: 'Dashboard summary' })
+  getSummary(@CurrentUser() user: JwtPayload) {
+    return this.dashboardService.getSummary(user);
+  }
+}

--- a/src/modules/dashboard/dashboard.module.ts
+++ b/src/modules/dashboard/dashboard.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Club } from '../clubs/entities/club.entity';
+import { Registration } from '../registrations/entities/registration.entity';
+import { Tournament } from '../tournaments/entities/tournament.entity';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './dashboard.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tournament, Club, Registration])],
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/modules/dashboard/dashboard.service.spec.ts
+++ b/src/modules/dashboard/dashboard.service.spec.ts
@@ -1,0 +1,94 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UserRole, RegistrationStatus } from '../../common/enums';
+import { Club } from '../clubs/entities/club.entity';
+import { Registration } from '../registrations/entities/registration.entity';
+import { Tournament } from '../tournaments/entities/tournament.entity';
+import { DashboardService } from './dashboard.service';
+
+const createRegistrationQueryBuilder = (
+  recentRegistrations: Partial<Registration>[],
+  statsRows: Array<{ status: RegistrationStatus; count: string }>,
+) => ({
+  leftJoinAndSelect: jest.fn().mockReturnThis(),
+  innerJoin: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  addSelect: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  groupBy: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  getMany: jest.fn().mockResolvedValue(recentRegistrations),
+  getRawMany: jest.fn().mockResolvedValue(statsRows),
+});
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+
+  const recentTournaments = [{ id: 'tournament-1', name: 'Cup' }];
+  const recentClubs = [{ id: 'club-1', name: 'Club' }];
+  const recentRegistrations = [{ id: 'registration-1' }];
+  const statsRows = [
+    { status: RegistrationStatus.APPROVED, count: '3' },
+    { status: RegistrationStatus.PENDING, count: '2' },
+    { status: RegistrationStatus.PENDING_PAYMENT, count: '1' },
+  ];
+
+  const tournamentRepository = {
+    find: jest.fn().mockResolvedValue(recentTournaments),
+    count: jest.fn().mockResolvedValue(7),
+  };
+  const clubRepository = {
+    find: jest.fn().mockResolvedValue(recentClubs),
+    count: jest.fn().mockResolvedValue(4),
+  };
+  const registrationRepository = {
+    createQueryBuilder: jest
+      .fn()
+      .mockImplementation(() =>
+        createRegistrationQueryBuilder(recentRegistrations, statsRows),
+      ),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        { provide: getRepositoryToken(Tournament), useValue: tournamentRepository },
+        { provide: getRepositoryToken(Club), useValue: clubRepository },
+        { provide: getRepositoryToken(Registration), useValue: registrationRepository },
+      ],
+    }).compile();
+
+    service = module.get(DashboardService);
+    jest.clearAllMocks();
+  });
+
+  it('returns compact summary for an organizer without per-tournament requests', async () => {
+    const summary = await service.getSummary({
+      sub: 'organizer-1',
+      email: 'organizer@example.com',
+      role: UserRole.ORGANIZER,
+    });
+
+    expect(summary).toEqual({
+      stats: {
+        tournaments: 7,
+        clubs: 4,
+        registrations: 6,
+        approved: 3,
+        pending: 3,
+      },
+      recentTournaments,
+      recentClubs,
+      recentRegistrations,
+    });
+    expect(tournamentRepository.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizerId: 'organizer-1' },
+        take: 5,
+      }),
+    );
+    expect(registrationRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,134 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Club } from '../clubs/entities/club.entity';
+import { Registration } from '../registrations/entities/registration.entity';
+import { Tournament } from '../tournaments/entities/tournament.entity';
+import { UserRole, RegistrationStatus } from '../../common/enums';
+import { JwtPayload } from '../../common/interfaces';
+
+@Injectable()
+export class DashboardService {
+  constructor(
+    @InjectRepository(Tournament)
+    private tournamentsRepository: Repository<Tournament>,
+    @InjectRepository(Club)
+    private clubsRepository: Repository<Club>,
+    @InjectRepository(Registration)
+    private registrationsRepository: Repository<Registration>,
+  ) {}
+
+  async getSummary(user: JwtPayload) {
+    const [recentTournaments, recentClubs] = await Promise.all([
+      this.tournamentsRepository.find({
+        where: { organizerId: user.sub },
+        relations: ['ageGroups'],
+        order: { createdAt: 'DESC' },
+        take: 5,
+      }),
+      this.clubsRepository.find({
+        where: { organizerId: user.sub },
+        order: { createdAt: 'DESC' },
+        take: 5,
+      }),
+    ]);
+
+    const [tournamentsCount, clubsCount] = await Promise.all([
+      this.tournamentsRepository.count({ where: { organizerId: user.sub } }),
+      this.clubsRepository.count({ where: { organizerId: user.sub } }),
+    ]);
+
+    const recentRegistrations = await this.getRecentRegistrations(user);
+    const registrationStats = await this.getRegistrationStats(user);
+
+    return {
+      stats: {
+        tournaments: tournamentsCount,
+        clubs: clubsCount,
+        registrations: registrationStats.total,
+        approved: registrationStats.approved,
+        pending: registrationStats.pending,
+      },
+      recentTournaments,
+      recentClubs,
+      recentRegistrations,
+    };
+  }
+
+  private async getRecentRegistrations(
+    user: JwtPayload,
+  ): Promise<Registration[]> {
+    const queryBuilder = this.registrationsRepository
+      .createQueryBuilder('registration')
+      .leftJoinAndSelect('registration.club', 'club')
+      .leftJoinAndSelect('registration.team', 'team')
+      .leftJoinAndSelect('registration.tournament', 'tournament')
+      .leftJoinAndSelect('registration.ageGroup', 'ageGroup')
+      .orderBy('registration.registrationDate', 'DESC')
+      .take(5);
+
+    if (user.role === UserRole.ORGANIZER || user.role === UserRole.ADMIN) {
+      queryBuilder.where('tournament.organizerId = :userId', {
+        userId: user.sub,
+      });
+      return queryBuilder.getMany();
+    }
+
+    const clubIds = await this.getUserClubIds(user.sub);
+    if (clubIds.length === 0) return [];
+
+    return queryBuilder
+      .where('registration.clubId IN (:...clubIds)', { clubIds })
+      .getMany();
+  }
+
+  private async getRegistrationStats(user: JwtPayload) {
+    const queryBuilder = this.registrationsRepository
+      .createQueryBuilder('registration')
+      .select('registration.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('registration.status');
+
+    if (user.role === UserRole.ORGANIZER || user.role === UserRole.ADMIN) {
+      queryBuilder
+        .innerJoin('registration.tournament', 'tournament')
+        .where('tournament.organizerId = :userId', { userId: user.sub });
+    } else {
+      const clubIds = await this.getUserClubIds(user.sub);
+      if (clubIds.length === 0) {
+        return { total: 0, approved: 0, pending: 0 };
+      }
+      queryBuilder.where('registration.clubId IN (:...clubIds)', { clubIds });
+    }
+
+    const rows = await queryBuilder.getRawMany<{
+      status: RegistrationStatus;
+      count: string;
+    }>();
+    const counts = rows.reduce(
+      (acc, row) => {
+        const count = parseInt(row.count, 10) || 0;
+        acc.total += count;
+        if (row.status === RegistrationStatus.APPROVED) acc.approved += count;
+        if (
+          row.status === RegistrationStatus.PENDING ||
+          row.status === RegistrationStatus.PENDING_PAYMENT
+        ) {
+          acc.pending += count;
+        }
+        return acc;
+      },
+      { total: 0, approved: 0, pending: 0 },
+    );
+
+    return counts;
+  }
+
+  private async getUserClubIds(userId: string): Promise<string[]> {
+    const clubs = await this.clubsRepository.find({
+      where: { organizerId: userId },
+      select: ['id'],
+    });
+    return clubs.map((club) => club.id);
+  }
+}

--- a/src/modules/groups/dto/group.dto.ts
+++ b/src/modules/groups/dto/group.dto.ts
@@ -8,6 +8,7 @@ import {
   IsISO8601,
   ValidateIf,
   IsBoolean,
+  IsIn,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -162,6 +163,25 @@ export class UpdateMatchScoreDto {
   @IsOptional()
   @IsString()
   status?: string;
+}
+
+
+export class SwapMatchTeamsDto {
+  @ApiProperty({ description: 'Source match ID' })
+  @IsString()
+  sourceMatchId: string;
+
+  @ApiProperty({ description: 'Source team slot', enum: ['team1', 'team2'] })
+  @IsIn(['team1', 'team2'])
+  sourceSlot: 'team1' | 'team2';
+
+  @ApiProperty({ description: 'Target match ID' })
+  @IsString()
+  targetMatchId: string;
+
+  @ApiProperty({ description: 'Target team slot', enum: ['team1', 'team2'] })
+  @IsIn(['team1', 'team2'])
+  targetSlot: 'team1' | 'team2';
 }
 
 /** BE-07 — Schedule a match (set date/time and optional court number) */

--- a/src/modules/groups/groups.controller.ts
+++ b/src/modules/groups/groups.controller.ts
@@ -28,6 +28,7 @@ import {
   UpdateMatchAdvancementDto,
   UpdateMatchScoreDto,
   ScheduleMatchDto,
+  SwapMatchTeamsDto,
 } from './dto';
 import {
   AssignTeamToPotDto,
@@ -209,6 +210,27 @@ export class GroupsController {
     @Query('ageGroupId') ageGroupId?: string,
   ) {
     return this.groupsService.getMatches(tournamentId, ageGroupId);
+  }
+
+  @Patch('matches/swap-teams')
+  @ApiOperation({ summary: 'Swap two teams between pending knockout match slots' })
+  @ApiResponse({ status: 200, description: 'Match teams swapped' })
+  @ApiResponse({ status: 400, description: 'Invalid swap' })
+  @ApiResponse({ status: 403, description: 'Not authorized' })
+  @ApiResponse({ status: 404, description: 'Match not found' })
+  swapMatchTeams(
+    @Param('tournamentId', ParseUUIDPipe) tournamentId: string,
+    @CurrentUser() user: JwtPayload,
+    @Body() dto: SwapMatchTeamsDto,
+    @Query('ageGroupId') ageGroupId?: string,
+  ) {
+    return this.groupsService.swapMatchTeams(
+      tournamentId,
+      user.sub,
+      user.role,
+      dto,
+      ageGroupId,
+    );
   }
 
   @Patch('matches/:matchId/advance')

--- a/src/modules/groups/groups.service.spec.ts
+++ b/src/modules/groups/groups.service.spec.ts
@@ -290,16 +290,19 @@ describe('GroupsService', () => {
   describe('getGroups', () => {
     it('should return groups for a tournament', async () => {
       mockGroupsRepo.find.mockResolvedValue([mockGroup]);
-      mockRegistrationsRepo.findOne.mockResolvedValue(mockRegistrations[0]);
+      mockRegistrationsRepo.find.mockResolvedValue(mockRegistrations.slice(0, 2));
 
       const result = await service.getGroups('tournament-1');
 
       expect(result).toHaveLength(1);
       expect(result[0].groupLetter).toBe('A');
-      expect(mockRegistrationsRepo.findOne).toHaveBeenCalledWith({
-        where: { id: 'reg-1' },
-        relations: ['club', 'team'],
-      });
+      expect((result[0] as any).teamDetails).toHaveLength(2);
+      expect(mockRegistrationsRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relations: ['club', 'team'],
+        }),
+      );
+      expect(mockRegistrationsRepo.findOne).not.toHaveBeenCalled();
     });
 
     it('should prefer team names over club names in matches responses', async () => {
@@ -359,793 +362,9 @@ describe('GroupsService', () => {
     });
   });
 
-  describe('getBracket', () => {
-    it('should return bracket information', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue(mockTournament);
-      mockGroupsRepo.find.mockResolvedValue([mockGroup]);
-      mockRegistrationsRepo.findOne.mockResolvedValue(mockRegistrations[0]);
 
-      const result = await service.getBracket('tournament-1');
-
-      expect(result).toHaveProperty('groups');
-      expect(result).toHaveProperty('tournament');
-      expect(result).toHaveProperty('drawCompleted');
-      expect(result.drawCompleted).toBe(false);
-    });
-
-    it('should throw NotFoundException if tournament not found', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue(null);
-
-      await expect(service.getBracket('non-existent')).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-  });
-
-  describe('resetDraw', () => {
-    it('should clear scoped bracket data when resetting one age group', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        bracketData: {
-          'age-group-1': {
-            type: 'GROUPS_PLUS_KNOCKOUT',
-            matches: [{ id: 'm1' }],
-          },
-          'age-group-2': {
-            type: 'GROUPS_PLUS_KNOCKOUT',
-            matches: [{ id: 'm2' }],
-          },
-        },
-      });
-      mockGroupsRepo.delete.mockResolvedValue({ affected: 2 });
-      mockRegistrationsRepo.update.mockResolvedValue({ affected: 4 });
-      mockAgeGroupRepo.update.mockResolvedValue({ affected: 1 });
-      mockTournamentsRepo.save.mockImplementation(
-        async (entity: any) => entity,
-      );
-
-      await service.resetDraw(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(mockGroupsRepo.delete).toHaveBeenCalledWith({
-        tournamentId: 'tournament-1',
-        ageGroupId: 'age-group-1',
-      });
-      expect(mockRegistrationsRepo.update).toHaveBeenCalledWith(
-        { tournamentId: 'tournament-1', ageGroupId: 'age-group-1' },
-        { groupAssignment: null },
-      );
-      expect(mockAgeGroupRepo.update).toHaveBeenCalledWith('age-group-1', {
-        drawCompleted: false,
-        drawSeed: undefined,
-      });
-      expect(mockTournamentsRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          bracketData: {
-            'age-group-2': {
-              type: 'GROUPS_PLUS_KNOCKOUT',
-              matches: [{ id: 'm2' }],
-            },
-          },
-        }),
-      );
-    });
-
-    it('should clear all bracket data on full reset', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        drawCompleted: true,
-        drawSeed: 'seed-1',
-        bracketData: {
-          'age-group-1': {
-            type: 'GROUPS_PLUS_KNOCKOUT',
-            matches: [{ id: 'm1' }],
-          },
-        },
-      });
-      mockGroupsRepo.delete.mockResolvedValue({ affected: 4 });
-      mockRegistrationsRepo.update.mockResolvedValue({ affected: 8 });
-      mockTournamentsRepo.save.mockImplementation(
-        async (entity: any) => entity,
-      );
-
-      await service.resetDraw(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-      );
-
-      expect(mockGroupsRepo.delete).toHaveBeenCalledWith({
-        tournamentId: 'tournament-1',
-      });
-      expect(mockTournamentsRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({
-          drawCompleted: false,
-          drawSeed: undefined,
-          bracketData: undefined,
-        }),
-      );
-    });
-  });
-
-  describe('generateBracket', () => {
-    it('should pass persisted leagueLegs to league bracket generation', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [
-          {
-            id: 'age-group-1',
-            format: 'LEAGUE',
-            leagueLegs: 1,
-          },
-        ],
-        bracketData: {},
-      });
-      mockRegistrationsRepo.find.mockResolvedValue([
-        {
-          id: 'reg-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 1' },
-        },
-        {
-          id: 'reg-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 2' },
-        },
-      ]);
-      mockBracketGeneratorService.generateBracket.mockReturnValue({
-        type: 'LEAGUE',
-        matches: [
-          { id: 'leg1_1', round: 1, matchNumber: 1, status: 'PENDING' },
-        ],
-      });
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      await service.generateBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(mockBracketGeneratorService.generateBracket).toHaveBeenCalledWith(
-        'LEAGUE',
-        2,
-        expect.objectContaining({ leagueLegs: 1 }),
-      );
-    });
-
-    it('should scope group-stage match generation to the requested age group', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [
-          {
-            id: 'age-group-1',
-            format: 'GROUPS_PLUS_KNOCKOUT',
-            groupsCount: 2,
-            qualifyingTeamsPerGroup: 2,
-            drawCompleted: true,
-          },
-        ],
-        bracketData: {},
-      });
-      mockRegistrationsRepo.find.mockResolvedValue([
-        {
-          id: 'reg-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 1' },
-        },
-        {
-          id: 'reg-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 2' },
-        },
-        {
-          id: 'reg-3',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 3' },
-        },
-        {
-          id: 'reg-4',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 4' },
-        },
-      ]);
-      mockBracketGeneratorService.generateBracket.mockReturnValue({
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        matches: [],
-        playoffRounds: [],
-      });
-      mockGroupsRepo.find.mockResolvedValue([
-        {
-          id: 'legacy-group',
-          tournamentId: 'tournament-1',
-          ageGroupId: undefined,
-          groupLetter: 'A',
-          teams: ['legacy-1', 'legacy-2', 'legacy-3', 'legacy-4'],
-        },
-        {
-          id: 'group-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'E',
-          teams: ['reg-1', 'reg-2'],
-        },
-        {
-          id: 'group-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'F',
-          teams: ['reg-3', 'reg-4'],
-        },
-      ]);
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(mockGroupsRepo.find).toHaveBeenCalledWith({
-        where: { tournamentId: 'tournament-1', ageGroupId: 'age-group-1' },
-        order: { groupLetter: 'ASC' },
-      });
-      expect(result.matches).toHaveLength(2);
-      expect(
-        result.matches.every((match: any) =>
-          ['E', 'F'].includes(match.groupLetter),
-        ),
-      ).toBe(true);
-    });
-
-    it('should keep the knockout shell visible for groups plus knockout brackets', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [
-          {
-            id: 'age-group-1',
-            format: 'GROUPS_PLUS_KNOCKOUT',
-            groupsCount: 2,
-            qualifyingTeamsPerGroup: 1,
-            drawCompleted: true,
-          },
-        ],
-        bracketData: {},
-      });
-      mockRegistrationsRepo.find.mockResolvedValue([
-        {
-          id: 'reg-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 1' },
-        },
-        {
-          id: 'reg-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 2' },
-        },
-        {
-          id: 'reg-3',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 3' },
-        },
-        {
-          id: 'reg-4',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: 'Team 4' },
-        },
-      ]);
-      const playoffRounds = [
-        {
-          roundNumber: 1,
-          roundName: 'Final',
-          matches: [
-            { id: 'ko-1', round: 1, matchNumber: 1, status: 'PENDING' },
-          ],
-        },
-      ];
-      mockBracketGeneratorService.generateBracket.mockReturnValue({
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        advancingTeamsPerGroup: 1,
-        matches: [],
-        playoffRounds,
-      });
-      mockGroupsRepo.find.mockResolvedValue([
-        {
-          id: 'group-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'A',
-          teams: ['reg-1', 'reg-2'],
-        },
-        {
-          id: 'group-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'B',
-          teams: ['reg-3', 'reg-4'],
-        },
-      ]);
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(result.playoffRounds).toBe(playoffRounds);
-      expect(mockTournamentsRepo.update).toHaveBeenLastCalledWith(
-        'tournament-1',
-        {
-          bracketData: expect.objectContaining({
-            'age-group-1': expect.objectContaining({ playoffRounds }),
-          }),
-        },
-      );
-    });
-
-    it('should create recursive placement bracket tabs for all group positions', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [
-          {
-            id: 'age-group-1',
-            format: 'GROUPS_PLUS_KNOCKOUT',
-            groupsCount: 4,
-            qualifyingTeamsPerGroup: 2,
-            drawCompleted: true,
-          },
-        ],
-        bracketData: {},
-      });
-      mockRegistrationsRepo.find.mockResolvedValue(
-        Array.from({ length: 16 }, (_, index) => ({
-          id: `reg-${index + 1}`,
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: `Team ${index + 1}` },
-        })),
-      );
-      mockBracketGeneratorService.generateBracket.mockReturnValue({
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        advancingTeamsPerGroup: 2,
-        matches: [],
-        playoffRounds: [],
-      });
-      mockGroupsRepo.find.mockResolvedValue(
-        ['A', 'B', 'C', 'D'].map((groupLetter, groupIndex) => ({
-          id: `group-${groupLetter}`,
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter,
-          teams: Array.from(
-            { length: 4 },
-            (_, teamIndex) => `reg-${groupIndex * 4 + teamIndex + 1}`,
-          ),
-        })),
-      );
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(result.placementBrackets.map((bracket: any) => bracket.label)).toEqual([
-        '1-8',
-        '9-16',
-      ]);
-      expect(result.placementBrackets[0].children.winners.label).toBe('1-4');
-      expect(result.placementBrackets[0].children.losers.label).toBe('5-8');
-      expect(result.placementBrackets[0].playoffRounds[0].matches[0]).toEqual(
-        expect.objectContaining({
-          team1SourceSlot: 'A1',
-          team2SourceSlot: 'D2',
-          nextMatchId: 'placement-1-4-r1-m1',
-          loserNextMatchId: 'placement-5-8-r1-m1',
-        }),
-      );
-    });
-
-    it('should build placement ranges from qualifying teams per group without odd zero-match branches', async () => {
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [
-          {
-            id: 'age-group-1',
-            format: 'GROUPS_PLUS_KNOCKOUT',
-            groupsCount: 2,
-            teamsPerGroup: 5,
-            qualifyingTeamsPerGroup: 2,
-            drawCompleted: true,
-          },
-        ],
-        bracketData: {},
-      });
-      mockRegistrationsRepo.find.mockResolvedValue(
-        Array.from({ length: 10 }, (_, index) => ({
-          id: `reg-${index + 1}`,
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          status: RegistrationStatus.APPROVED,
-          club: { name: `Team ${index + 1}` },
-        })),
-      );
-      mockBracketGeneratorService.generateBracket.mockReturnValue({
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        advancingTeamsPerGroup: 2,
-        matches: [],
-        playoffRounds: [],
-      });
-      mockGroupsRepo.find.mockResolvedValue(
-        ['A', 'B'].map((groupLetter, groupIndex) => ({
-          id: `group-${groupLetter}`,
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter,
-          teams: Array.from(
-            { length: 5 },
-            (_, teamIndex) => `reg-${groupIndex * 5 + teamIndex + 1}`,
-          ),
-        })),
-      );
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      const walk = (bracket: any): any[] => [
-        bracket,
-        ...(bracket.children?.winners ? walk(bracket.children.winners) : []),
-        ...(bracket.children?.losers ? walk(bracket.children.losers) : []),
-      ];
-      const allPlacementNodes = result.placementBrackets.flatMap((bracket: any) =>
-        walk(bracket),
-      );
-
-      expect(result.placementBrackets.map((bracket: any) => bracket.label)).toEqual([
-        '1-4',
-        '5-8',
-        '9-10',
-      ]);
-      expect(
-        allPlacementNodes.every(
-          (bracket: any) => bracket.playoffRounds[0].matches.length > 0,
-        ),
-      ).toBe(true);
-      expect(result.placementBrackets[0].children.winners.label).toBe('1-2');
-      expect(result.placementBrackets[0].children.losers.label).toBe('3-4');
-      expect(result.placementBrackets[2].children).toBeUndefined();
-    });
-  });
-
-  describe('generateKnockoutBracket', () => {
-    it('should create a provisional knockout shell before group matches are completed', async () => {
-      const bracketData: any = {
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        advancingTeamsPerGroup: 1,
-        matches: [
-          {
-            id: 'grp_A_1',
-            round: 1,
-            matchNumber: 1,
-            groupLetter: 'A',
-            team1Id: 'reg-1',
-            team1Name: 'Team 1',
-            team2Id: 'reg-2',
-            team2Name: 'Team 2',
-            status: 'PENDING',
-          },
-          {
-            id: 'grp_B_1',
-            round: 1,
-            matchNumber: 1,
-            groupLetter: 'B',
-            team1Id: 'reg-3',
-            team1Name: 'Team 3',
-            team2Id: 'reg-4',
-            team2Name: 'Team 4',
-            status: 'PENDING',
-          },
-        ],
-      };
-      const playoffRounds = [
-        {
-          roundNumber: 1,
-          roundName: 'Final',
-          matches: [
-            { id: 'ko-1', round: 1, matchNumber: 1, status: 'PENDING' },
-          ],
-        },
-      ];
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [{ id: 'age-group-1', format: 'GROUPS_PLUS_KNOCKOUT' }],
-        bracketData: { 'age-group-1': bracketData },
-      });
-      mockGroupsRepo.find.mockResolvedValue([
-        {
-          id: 'group-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'A',
-          teams: ['reg-1', 'reg-2'],
-        },
-        {
-          id: 'group-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'B',
-          teams: ['reg-3', 'reg-4'],
-        },
-      ]);
-      mockBracketGeneratorService.generateBracket.mockReturnValue({
-        type: 'SINGLE_ELIMINATION',
-        playoffRounds,
-      });
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateKnockoutBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(result.playoffRounds).toBe(playoffRounds);
-      expect(mockBracketGeneratorService.seedTeamsIntoBracket).not.toHaveBeenCalled();
-      expect(mockTournamentsRepo.update).toHaveBeenCalledWith('tournament-1', {
-        bracketData: {
-          'age-group-1': expect.objectContaining({ playoffRounds }),
-        },
-      });
-    });
-
-    it('should seed an existing knockout shell and preserve scheduled match details', async () => {
-      const scheduledAt = new Date('2026-06-22T10:00:00.000Z');
-      const bracketData = {
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        advancingTeamsPerGroup: 1,
-        matches: [
-          {
-            id: 'grp_A_1',
-            round: 1,
-            matchNumber: 1,
-            groupLetter: 'A',
-            team1Id: 'reg-1',
-            team1Name: 'Team 1',
-            team1Score: 2,
-            team2Id: 'reg-2',
-            team2Name: 'Team 2',
-            team2Score: 0,
-            status: 'COMPLETED',
-          },
-          {
-            id: 'grp_B_1',
-            round: 1,
-            matchNumber: 1,
-            groupLetter: 'B',
-            team1Id: 'reg-3',
-            team1Name: 'Team 3',
-            team1Score: 3,
-            team2Id: 'reg-4',
-            team2Name: 'Team 4',
-            team2Score: 1,
-            status: 'COMPLETED',
-          },
-        ],
-        playoffRounds: [
-          {
-            roundNumber: 1,
-            roundName: 'Final',
-            matches: [
-              {
-                id: 'ko-1',
-                round: 1,
-                matchNumber: 1,
-                status: 'PENDING',
-                scheduledAt,
-                fieldName: 'Pitch 2',
-              },
-            ],
-          },
-        ],
-      };
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [{ id: 'age-group-1', format: 'GROUPS_PLUS_KNOCKOUT' }],
-        bracketData: { 'age-group-1': bracketData },
-      });
-      mockGroupsRepo.find.mockResolvedValue([
-        {
-          id: 'group-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'A',
-          teams: ['reg-1', 'reg-2'],
-        },
-        {
-          id: 'group-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'B',
-          teams: ['reg-3', 'reg-4'],
-        },
-      ]);
-      mockBracketGeneratorService.calculateGroupStandings
-        .mockReturnValueOnce([{ teamId: 'reg-1', position: 1 }])
-        .mockReturnValueOnce([{ teamId: 'reg-3', position: 1 }]);
-      mockBracketGeneratorService.seedTeamsIntoBracket.mockImplementation(
-        (_standings, _advancing, data) => {
-          data.playoffRounds[0].matches[0].team1Id = 'reg-1';
-          data.playoffRounds[0].matches[0].team2Id = 'reg-3';
-          return data;
-        },
-      );
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateKnockoutBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(mockGroupsRepo.find).toHaveBeenCalledWith({
-        where: { tournamentId: 'tournament-1', ageGroupId: 'age-group-1' },
-        order: { groupLetter: 'ASC' },
-      });
-      expect(result.playoffRounds[0].matches[0]).toEqual(
-        expect.objectContaining({
-          team1Id: 'reg-1',
-          team1Name: 'Team 1',
-          team2Id: 'reg-3',
-          team2Name: 'Team 3',
-          scheduledAt,
-          fieldName: 'Pitch 2',
-        }),
-      );
-      expect(mockTournamentsRepo.update).toHaveBeenCalledWith('tournament-1', {
-        bracketData: { 'age-group-1': result },
-      });
-    });
-
-    it('should seed placement brackets from completed group standings', async () => {
-      const bracketData = {
-        type: 'GROUPS_PLUS_KNOCKOUT',
-        advancingTeamsPerGroup: 1,
-        matches: [
-          {
-            id: 'grp_A_1',
-            round: 1,
-            matchNumber: 1,
-            groupLetter: 'A',
-            team1Id: 'reg-1',
-            team1Name: 'Team 1',
-            team1Score: 2,
-            team2Id: 'reg-2',
-            team2Name: 'Team 2',
-            team2Score: 0,
-            status: 'COMPLETED',
-          },
-          {
-            id: 'grp_B_1',
-            round: 1,
-            matchNumber: 1,
-            groupLetter: 'B',
-            team1Id: 'reg-3',
-            team1Name: 'Team 3',
-            team1Score: 3,
-            team2Id: 'reg-4',
-            team2Name: 'Team 4',
-            team2Score: 1,
-            status: 'COMPLETED',
-          },
-        ],
-        playoffRounds: [
-          {
-            roundNumber: 1,
-            roundName: 'Final',
-            matches: [
-              { id: 'ko-1', round: 1, matchNumber: 1, status: 'PENDING' },
-            ],
-          },
-        ],
-      };
-      mockTournamentsRepo.findOne.mockResolvedValue({
-        ...mockTournament,
-        ageGroups: [{ id: 'age-group-1', format: 'GROUPS_PLUS_KNOCKOUT' }],
-        bracketData: { 'age-group-1': bracketData },
-      });
-      mockGroupsRepo.find.mockResolvedValue([
-        {
-          id: 'group-1',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'A',
-          teams: ['reg-1', 'reg-2'],
-        },
-        {
-          id: 'group-2',
-          tournamentId: 'tournament-1',
-          ageGroupId: 'age-group-1',
-          groupLetter: 'B',
-          teams: ['reg-3', 'reg-4'],
-        },
-      ]);
-      mockBracketGeneratorService.calculateGroupStandings.mockImplementation(
-        (teams: string[]) =>
-          teams.map((teamId, index) => ({ teamId, position: index + 1 })),
-      );
-      mockBracketGeneratorService.seedTeamsIntoBracket.mockImplementation(
-        (_standings, _advancing, data) => data,
-      );
-      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
-
-      const result = await service.generateKnockoutBracket(
-        'tournament-1',
-        'organizer-1',
-        UserRole.ORGANIZER,
-        'age-group-1',
-      );
-
-      expect(result.placementBrackets[0].playoffRounds[0].matches[0]).toEqual(
-        expect.objectContaining({
-          team1SourceSlot: 'A1',
-          team1Id: 'reg-1',
-          team1Name: 'Team 1',
-          team2SourceSlot: 'B1',
-          team2Id: 'reg-3',
-          team2Name: 'Team 3',
-        }),
-      );
-      expect(result.placementBrackets[1].playoffRounds[0].matches[0]).toEqual(
-        expect.objectContaining({
-          team1SourceSlot: 'A2',
-          team1Id: 'reg-2',
-          team2SourceSlot: 'B2',
-          team2Id: 'reg-4',
-        }),
-      );
-    });
-  });
-
-  describe('updateMatchScore', () => {
-    it('should propagate placement winners and losers into the next nested tabs', async () => {
+  describe('swapMatchTeams', () => {
+    it('should swap two pending teams inside placement bracket slots', async () => {
       const bracketData: any = {
         type: 'GROUPS_PLUS_KNOCKOUT',
         matches: [],
@@ -1166,58 +385,27 @@ describe('GroupsService', () => {
                     round: 1,
                     matchNumber: 1,
                     status: 'PENDING',
+                    team1Score: null,
+                    team2Score: null,
+                    winnerId: null,
                     team1Id: 'reg-1',
                     team1Name: 'Team 1',
+                    team2Id: 'reg-2',
+                    team2Name: 'Team 2',
+                  },
+                  {
+                    id: 'placement-1-4-r1-m2',
+                    round: 1,
+                    matchNumber: 2,
+                    status: 'PENDING',
+                    team1Id: 'reg-3',
+                    team1Name: 'Team 3',
                     team2Id: 'reg-4',
                     team2Name: 'Team 4',
-                    nextMatchId: 'placement-1-2-r1-m1',
-                    loserNextMatchId: 'placement-3-4-r1-m1',
                   },
                 ],
               },
             ],
-            children: {
-              winners: {
-                key: 'placement-1-2',
-                label: '1-2',
-                rangeStart: 1,
-                rangeEnd: 2,
-                playoffRounds: [
-                  {
-                    roundNumber: 1,
-                    roundName: '1-2',
-                    matches: [
-                      {
-                        id: 'placement-1-2-r1-m1',
-                        round: 1,
-                        matchNumber: 1,
-                        status: 'PENDING',
-                      },
-                    ],
-                  },
-                ],
-              },
-              losers: {
-                key: 'placement-3-4',
-                label: '3-4',
-                rangeStart: 3,
-                rangeEnd: 4,
-                playoffRounds: [
-                  {
-                    roundNumber: 1,
-                    roundName: '3-4',
-                    matches: [
-                      {
-                        id: 'placement-3-4-r1-m1',
-                        round: 1,
-                        matchNumber: 1,
-                        status: 'PENDING',
-                      },
-                    ],
-                  },
-                ],
-              },
-            },
           },
         ],
       };
@@ -1227,27 +415,162 @@ describe('GroupsService', () => {
       });
       mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
 
-      const result = await service.updateMatchScore(
+      const result = await service.swapMatchTeams(
         'tournament-1',
-        'placement-1-4-r1-m1',
         'organizer-1',
         UserRole.ORGANIZER,
-        { team1Score: 2, team2Score: 1 },
+        {
+          sourceMatchId: 'placement-1-4-r1-m1',
+          sourceSlot: 'team1',
+          targetMatchId: 'placement-1-4-r1-m2',
+          targetSlot: 'team2',
+        },
         'age-group-1',
       );
 
+      const [firstMatch, secondMatch] =
+        bracketData.placementBrackets[0].playoffRounds[0].matches;
+      expect(firstMatch.team1Id).toBe('reg-4');
+      expect(firstMatch.team1Name).toBe('Team 4');
+      expect(secondMatch.team2Id).toBe('reg-1');
+      expect(secondMatch.team2Name).toBe('Team 1');
       expect(result.bracketUpdated).toBe(true);
-      expect(
-        bracketData.placementBrackets[0].children.winners.playoffRounds[0]
-          .matches[0].team1Id,
-      ).toBe('reg-1');
-      expect(
-        bracketData.placementBrackets[0].children.losers.playoffRounds[0]
-          .matches[0].team1Id,
-      ).toBe('reg-4');
       expect(mockTournamentsRepo.update).toHaveBeenCalledWith('tournament-1', {
         bracketData: { 'age-group-1': bracketData },
       });
+    });
+
+    it('should swap provisional source slots before group matches are completed', async () => {
+      const bracketData: any = {
+        type: 'GROUPS_PLUS_KNOCKOUT',
+        matches: [
+          {
+            id: 'grp_A_1',
+            groupLetter: 'A',
+            status: 'PENDING',
+          },
+        ],
+        playoffRounds: [],
+        placementBrackets: [
+          {
+            key: 'placement-1-4',
+            label: '1-4',
+            rangeStart: 1,
+            rangeEnd: 4,
+            playoffRounds: [
+              {
+                roundNumber: 1,
+                roundName: '1-4',
+                matches: [
+                  {
+                    id: 'placement-1-4-r1-m1',
+                    round: 1,
+                    matchNumber: 1,
+                    status: 'PENDING',
+                    team1Name: 'A1',
+                    team1SourceSlot: 'A1',
+                    team2Name: 'B2',
+                    team2SourceSlot: 'B2',
+                  },
+                  {
+                    id: 'placement-1-4-r1-m2',
+                    round: 1,
+                    matchNumber: 2,
+                    status: 'PENDING',
+                    team1Name: 'A2',
+                    team1SourceSlot: 'A2',
+                    team2Name: 'B1',
+                    team2SourceSlot: 'B1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      mockTournamentsRepo.findOne.mockResolvedValue({
+        ...mockTournament,
+        bracketData: { 'age-group-1': bracketData },
+      });
+      mockTournamentsRepo.update.mockResolvedValue({ affected: 1 });
+
+      await service.swapMatchTeams(
+        'tournament-1',
+        'organizer-1',
+        UserRole.ORGANIZER,
+        {
+          sourceMatchId: 'placement-1-4-r1-m1',
+          sourceSlot: 'team1',
+          targetMatchId: 'placement-1-4-r1-m2',
+          targetSlot: 'team2',
+        },
+        'age-group-1',
+      );
+
+      const [firstMatch, secondMatch] =
+        bracketData.placementBrackets[0].playoffRounds[0].matches;
+      expect(firstMatch.team1Name).toBe('B1');
+      expect(firstMatch.team1SourceSlot).toBe('B1');
+      expect(secondMatch.team2Name).toBe('A1');
+      expect(secondMatch.team2SourceSlot).toBe('A1');
+    });
+
+    it('should reject swapping teams from a scored match', async () => {
+      const bracketData: any = {
+        type: 'GROUPS_PLUS_KNOCKOUT',
+        placementBrackets: [
+          {
+            key: 'placement-1-4',
+            label: '1-4',
+            rangeStart: 1,
+            rangeEnd: 4,
+            playoffRounds: [
+              {
+                roundNumber: 1,
+                roundName: '1-4',
+                matches: [
+                  {
+                    id: 'm1',
+                    round: 1,
+                    matchNumber: 1,
+                    status: 'COMPLETED',
+                    team1Id: 'reg-1',
+                    team1Score: 1,
+                    team2Id: 'reg-2',
+                    team2Score: 0,
+                  },
+                  {
+                    id: 'm2',
+                    round: 1,
+                    matchNumber: 2,
+                    status: 'PENDING',
+                    team1Id: 'reg-3',
+                    team2Id: 'reg-4',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      mockTournamentsRepo.findOne.mockResolvedValue({
+        ...mockTournament,
+        bracketData,
+      });
+
+      await expect(
+        service.swapMatchTeams(
+          'tournament-1',
+          'organizer-1',
+          UserRole.ORGANIZER,
+          {
+            sourceMatchId: 'm1',
+            sourceSlot: 'team1',
+            targetMatchId: 'm2',
+            targetSlot: 'team1',
+          },
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/groups/groups.service.ts
+++ b/src/modules/groups/groups.service.ts
@@ -5,7 +5,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { Group } from './entities/group.entity';
 import { Tournament } from '../tournaments/entities/tournament.entity';
@@ -20,6 +20,7 @@ import {
   GroupConfigurationResponseDto,
   UpdateMatchAdvancementDto,
   UpdateMatchScoreDto,
+  SwapMatchTeamsDto,
 } from './dto';
 import {
   TournamentStatus,
@@ -611,19 +612,24 @@ export class GroupsService {
       order: { groupOrder: 'ASC' },
     });
 
-    // Populate team details
+    const registrationIds = Array.from(
+      new Set(groups.flatMap((group) => group.teams || [])),
+    );
+    const registrations = registrationIds.length
+      ? await this.registrationsRepository.find({
+          where: { id: In(registrationIds) },
+          relations: ['club', 'team'],
+        })
+      : [];
+    const registrationById = new Map(
+      registrations.map((registration) => [registration.id, registration]),
+    );
+
+    // Populate team details while preserving the group team order.
     for (const group of groups) {
-      // Replace team IDs with full registration data
-      const teamDetails = await Promise.all(
-        group.teams.map(async (teamId) => {
-          const registration = await this.registrationsRepository.findOne({
-            where: { id: teamId },
-            relations: ['club', 'team'],
-          });
-          return registration;
-        }),
-      );
-      (group as any).teamDetails = teamDetails.filter(Boolean);
+      (group as any).teamDetails = (group.teams || [])
+        .map((teamId) => registrationById.get(teamId))
+        .filter(Boolean);
     }
 
     return groups;
@@ -1460,6 +1466,152 @@ export class GroupsService {
       teams,
       advancingTeamsPerGroup: ageBracket.advancingTeamsPerGroup ?? undefined,
     };
+  }
+
+
+  private getTeamSlot(
+    match: Match,
+    slot: 'team1' | 'team2',
+  ): { teamId?: string; teamName?: string; sourceSlot?: string } {
+    return slot === 'team1'
+      ? {
+          teamId: match.team1Id,
+          teamName: match.team1Name,
+          sourceSlot: match.team1SourceSlot,
+        }
+      : {
+          teamId: match.team2Id,
+          teamName: match.team2Name,
+          sourceSlot: match.team2SourceSlot,
+        };
+  }
+
+  private setTeamSlot(
+    match: Match,
+    slot: 'team1' | 'team2',
+    team: { teamId?: string; teamName?: string; sourceSlot?: string },
+  ) {
+    if (slot === 'team1') {
+      match.team1Id = team.teamId;
+      match.team1Name = team.teamName;
+      match.team1SourceSlot = team.sourceSlot;
+      return;
+    }
+
+    match.team2Id = team.teamId;
+    match.team2Name = team.teamName;
+    match.team2SourceSlot = team.sourceSlot;
+  }
+
+  private isMatchLockedForTeamSwap(match: Match): boolean {
+    return (
+      match.status !== 'PENDING' ||
+      match.team1Score != null ||
+      match.team2Score != null ||
+      match.leg1Team1Score != null ||
+      match.leg1Team2Score != null ||
+      match.leg2Team1Score != null ||
+      match.leg2Team2Score != null ||
+      match.winnerId != null ||
+      match.loserId != null ||
+      match.manualWinnerId != null ||
+      match.hasPenalties === true ||
+      match.penaltyTeam1Score != null ||
+      match.penaltyTeam2Score != null
+    );
+  }
+
+  private assertMatchCanSwapTeams(match: Match) {
+    if (this.isMatchLockedForTeamSwap(match)) {
+      throw new BadRequestException(
+        'Teams can only be swapped before a match has started or received a score',
+      );
+    }
+  }
+
+
+  async swapMatchTeams(
+    tournamentId: string,
+    userId: string,
+    userRole: string,
+    dto: SwapMatchTeamsDto,
+    ageGroupId?: string,
+  ): Promise<{ sourceMatch: Match; targetMatch: Match; bracketUpdated: boolean }> {
+    const tournament = await this.tournamentsRepository.findOne({
+      where: { id: tournamentId },
+    });
+
+    if (!tournament) {
+      throw new NotFoundException('Tournament not found');
+    }
+
+    if (tournament.organizerId !== userId && userRole !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'You are not allowed to manage matches for this tournament',
+      );
+    }
+
+    if (!tournament.bracketData) {
+      throw new BadRequestException(
+        'No bracket data found for this tournament',
+      );
+    }
+
+    if (
+      dto.sourceMatchId === dto.targetMatchId &&
+      dto.sourceSlot === dto.targetSlot
+    ) {
+      throw new BadRequestException('Choose two different team slots to swap');
+    }
+
+    const fullBracketData = tournament.bracketData as any;
+    const bracketData =
+      this.getBracketForAgeGroup(fullBracketData, ageGroupId) ||
+      fullBracketData;
+
+    const sourceMatch = this.findMatchInBracket(
+      bracketData,
+      dto.sourceMatchId,
+    ) as Match | null;
+    const targetMatch = this.findMatchInBracket(
+      bracketData,
+      dto.targetMatchId,
+    ) as Match | null;
+
+    if (!sourceMatch) {
+      throw new NotFoundException(`Match ${dto.sourceMatchId} not found`);
+    }
+    if (!targetMatch) {
+      throw new NotFoundException(`Match ${dto.targetMatchId} not found`);
+    }
+
+    this.assertMatchCanSwapTeams(sourceMatch);
+    if (targetMatch !== sourceMatch) {
+      this.assertMatchCanSwapTeams(targetMatch);
+    }
+
+    const sourceTeam = this.getTeamSlot(sourceMatch, dto.sourceSlot);
+    const targetTeam = this.getTeamSlot(targetMatch, dto.targetSlot);
+
+    const sourceHasValue =
+      !!sourceTeam.teamId || !!sourceTeam.sourceSlot || !!sourceTeam.teamName;
+    const targetHasValue =
+      !!targetTeam.teamId || !!targetTeam.sourceSlot || !!targetTeam.teamName;
+
+    if (!sourceHasValue || !targetHasValue) {
+      throw new BadRequestException(
+        'Both selected slots must contain teams or provisional source slots',
+      );
+    }
+
+    this.setTeamSlot(sourceMatch, dto.sourceSlot, targetTeam);
+    this.setTeamSlot(targetMatch, dto.targetSlot, sourceTeam);
+
+    await this.tournamentsRepository.update(tournamentId, {
+      bracketData: fullBracketData,
+    });
+
+    return { sourceMatch, targetMatch, bracketUpdated: true };
   }
 
   async setMatchAdvancement(

--- a/src/modules/registrations/registrations.service.ts
+++ b/src/modules/registrations/registrations.service.ts
@@ -336,10 +336,7 @@ export class RegistrationsService {
     const queryBuilder = this.registrationsRepository
       .createQueryBuilder('registration')
       .leftJoinAndSelect('registration.club', 'club')
-      .leftJoinAndSelect('club.organizer', 'clubOrganizer')
       .leftJoinAndSelect('registration.team', 'team')
-      .leftJoinAndSelect('team.players', 'teamPlayers')
-      .leftJoinAndSelect('registration.tournament', 'tournament')
       .leftJoinAndSelect('registration.ageGroup', 'ageGroup')
       .where('registration.tournamentId = :tournamentId', { tournamentId });
 

--- a/src/modules/tournaments/tournaments.controller.ts
+++ b/src/modules/tournaments/tournaments.controller.ts
@@ -128,7 +128,7 @@ export class TournamentsController {
   @ApiResponse({ status: 200, description: 'Tournament details' })
   @ApiResponse({ status: 404, description: 'Tournament not found' })
   findOne(@Param('id', ParseUUIDPipe) id: string) {
-    return this.tournamentsService.findByIdOrFail(id);
+    return this.tournamentsService.findDetailsByIdOrFail(id);
   }
 
   @Patch(':id')

--- a/src/modules/tournaments/tournaments.service.ts
+++ b/src/modules/tournaments/tournaments.service.ts
@@ -544,6 +544,22 @@ export class TournamentsService {
     return this.enrichTournamentData(normalized);
   }
 
+  async findDetailsByIdOrFail(id: string): Promise<Tournament> {
+    await this.syncPastTournamentsAsCompleted();
+
+    const tournament = await this.tournamentsRepository.findOne({
+      where: { id },
+      relations: ['organizer', 'ageGroups'],
+    });
+
+    if (!tournament) {
+      throw new NotFoundException(`Tournament with ID ${id} not found`);
+    }
+
+    const normalized = await this.normalizeDraftStatus(tournament);
+    return this.enrichTournamentDetails(normalized);
+  }
+
   async findBySlug(slug: string): Promise<Tournament | null> {
     await this.syncPastTournamentsAsCompleted();
 
@@ -554,14 +570,19 @@ export class TournamentsService {
   }
 
   async findBySlugOrFail(slug: string): Promise<Tournament> {
-    const tournament = await this.findBySlug(slug);
+    await this.syncPastTournamentsAsCompleted();
+
+    const tournament = await this.tournamentsRepository.findOne({
+      where: { urlSlug: slug },
+      relations: ['organizer', 'ageGroups'],
+    });
 
     if (!tournament) {
       throw new NotFoundException(`Tournament with slug ${slug} not found`);
     }
 
     const normalized = await this.normalizeDraftStatus(tournament);
-    return this.enrichTournamentData(normalized);
+    return this.enrichTournamentDetails(normalized);
   }
 
   async findByOrganizer(organizerId: string): Promise<Tournament[]> {
@@ -604,6 +625,33 @@ export class TournamentsService {
         .sort()[0] ?? null;
 
     return Object.assign(tournament, { confirmedTeams, effectiveStartDate });
+  }
+
+  private async enrichTournamentDetails(
+    tournament: Tournament,
+  ): Promise<Tournament> {
+    const [{ count } = { count: '0' }] = await this.tournamentsRepository
+      .createQueryBuilder('tournament')
+      .leftJoin(
+        'tournament.registrations',
+        'registration',
+        'registration.status = :status',
+        { status: RegistrationStatus.APPROVED },
+      )
+      .select('COUNT(registration.id)', 'count')
+      .where('tournament.id = :id', { id: tournament.id })
+      .getRawMany<{ count: string }>();
+
+    const effectiveStartDate =
+      tournament.ageGroups
+        ?.map((ag) => ag.startDate)
+        .filter(Boolean)
+        .sort()[0] ?? null;
+
+    return Object.assign(tournament, {
+      confirmedTeams: parseInt(count, 10) || 0,
+      effectiveStartDate,
+    });
   }
 
   async update(


### PR DESCRIPTION
Add dashboard summary endpoints, optimize tournament/group reads, and support safe team swaps in pending knockout and provisional placement brackets.