### PR TITLE
Fix failing E2E tests (stale fixtures vs current DTO/pot model)

### DIFF
--- a/test/fixtures/tournaments.fixture.ts
+++ b/test/fixtures/tournaments.fixture.ts
@@ -1,14 +1,9 @@
 import { faker } from '@faker-js/faker';
-import {
-  TournamentStatus,
-  AgeCategory,
-  TournamentLevel,
-} from '../../src/common/enums';
+import { TournamentStatus, TournamentLevel } from '../../src/common/enums';
 
 interface TournamentOverrides {
   name?: string;
   description?: string;
-  ageCategory?: AgeCategory;
   level?: TournamentLevel;
   gameSystem?: string;
   numberOfMatches?: number;
@@ -31,6 +26,9 @@ export const createTournamentFixture = (
   const endDate = new Date(startDate);
   endDate.setDate(endDate.getDate() + 2);
 
+  // CreateTournamentDto requires date-only strings (YYYY-MM-DD).
+  const toDateOnly = (d: Date) => d.toISOString().slice(0, 10);
+
   // Note: status is set by the server, not by the client in CreateTournamentDto
   const {
     status: _status,
@@ -41,12 +39,11 @@ export const createTournamentFixture = (
   return {
     name: `${faker.company.name()} Cup ${faker.date.future().getFullYear()}`,
     description: faker.lorem.paragraph(),
-    ageCategory: AgeCategory.U12,
     level: TournamentLevel.LEVEL_I,
     gameSystem: '4+1',
     numberOfMatches: 6,
-    startDate: startDate.toISOString(),
-    endDate: endDate.toISOString(),
+    startDate: toDateOnly(startDate),
+    endDate: toDateOnly(endDate),
     location: 'Brașov, Romania',
     latitude: 45.6427,
     longitude: 25.5887,

--- a/test/pot-management.e2e-spec.ts
+++ b/test/pot-management.e2e-spec.ts
@@ -127,12 +127,11 @@ describe('Pot Management (e2e)', () => {
       .send({
         name: 'Pot Draw Test Cup 2026',
         description: 'E2E testing for pot management',
-        ageCategory: 'U12',
-        level: 'LEVEL_I',
+        level: 'I',
         gameSystem: '4+1',
         numberOfMatches: 6,
-        startDate: startDate.toISOString(),
-        endDate: endDate.toISOString(),
+        startDate: startDate.toISOString().slice(0, 10),
+        endDate: endDate.toISOString().slice(0, 10),
         location: 'Test City, Romania',
         latitude: 45.0,
         longitude: 25.0,
@@ -197,11 +196,10 @@ describe('Pot Management (e2e)', () => {
 
       registrationIds.push(regRes.body.data.id);
 
-      // Approve registration
+      // Approve registration (must be APPROVED — not PENDING_PAYMENT — to be
+      // assignable to pots)
       await request(app.getHttpServer())
-        .post(
-          `/api/v1/registrations/${regRes.body.data.id}/approve-without-payment`,
-        )
+        .post(`/api/v1/registrations/${regRes.body.data.id}/approve`)
         .set('Authorization', `Bearer ${organizerToken}`)
         .expect(201);
     }
@@ -227,14 +225,17 @@ describe('Pot Management (e2e)', () => {
   // 1. GET Pots (empty state)
   // -------------------------------------------------------
   describe('GET /api/v1/tournaments/:id/pots', () => {
-    it('should return 4 empty pots initially', async () => {
+    it('should return a single empty pot initially', async () => {
+      // Pots are returned dynamically based on the highest assigned pot number,
+      // with a floor of 1 (see PotDrawService.getPots). Before any assignment
+      // there is one empty pot.
       const res = await request(app.getHttpServer())
         .get(`/api/v1/tournaments/${tournamentId}/pots`)
         .set('Authorization', `Bearer ${organizerToken}`)
         .expect(200);
 
       expect(res.body.success).toBe(true);
-      expect(res.body.data).toHaveLength(4);
+      expect(res.body.data).toHaveLength(1);
       for (const pot of res.body.data) {
         expect(pot.count).toBe(0);
         expect(pot.teams).toHaveLength(0);
@@ -270,10 +271,11 @@ describe('Pot Management (e2e)', () => {
     });
 
     it('should reject invalid pot number', async () => {
+      // potNumber is validated to be between 1 and 32 (AssignTeamToPotDto)
       const res = await request(app.getHttpServer())
         .post(`/api/v1/tournaments/${tournamentId}/pots/assign`)
         .set('Authorization', `Bearer ${organizerToken}`)
-        .send({ registrationId: registrationIds[0], potNumber: 5 })
+        .send({ registrationId: registrationIds[0], potNumber: 33 })
         .expect(400);
 
       expect(res.body.success).toBe(false);
@@ -342,14 +344,15 @@ describe('Pot Management (e2e)', () => {
         .set('Authorization', `Bearer ${organizerToken}`)
         .expect(200);
 
+      // 6 teams across 3 pots (2 each); pots are returned dynamically, so
+      // there is no empty 4th pot.
+      expect(res.body.data).toHaveLength(3);
       expect(res.body.data[0].potNumber).toBe(1);
       expect(res.body.data[0].count).toBe(2);
       expect(res.body.data[1].potNumber).toBe(2);
       expect(res.body.data[1].count).toBe(2);
       expect(res.body.data[2].potNumber).toBe(3);
       expect(res.body.data[2].count).toBe(2);
-      expect(res.body.data[3].potNumber).toBe(4);
-      expect(res.body.data[3].count).toBe(0);
 
       // Verify team data is populated
       const firstTeam = res.body.data[0].teams[0];
@@ -402,10 +405,11 @@ describe('Pot Management (e2e)', () => {
     });
 
     it('should execute pot draw with 2 groups', async () => {
+      // 6 teams seeded across 3 pots (2 each) drawn into 2 groups of 3.
       const res = await request(app.getHttpServer())
         .post(`/api/v1/tournaments/${tournamentId}/pots/draw`)
         .set('Authorization', `Bearer ${organizerToken}`)
-        .send({ numberOfGroups: 2 })
+        .send({ numberOfGroups: 2, numberOfPots: 3 })
         .expect(201);
 
       expect(res.body.success).toBe(true);

--- a/test/tournaments.e2e-spec.ts
+++ b/test/tournaments.e2e-spec.ts
@@ -120,7 +120,8 @@ describe('Tournaments (e2e)', () => {
       expect(response.body.success).toBe(true);
       expect(response.body.data.id).toBeDefined();
       expect(response.body.data.name).toBe(tournamentFixture.name);
-      expect(response.body.data.status).toBe('DRAFT');
+      // Tournaments are created published (see TournamentsService.create)
+      expect(response.body.data.status).toBe('PUBLISHED');
     });
 
     it('should reject tournament creation without auth', async () => {
@@ -190,10 +191,11 @@ describe('Tournaments (e2e)', () => {
       expect(response.body.data.meta.limit).toBe(10);
     });
 
-    it('should filter by age category', async () => {
+    it('should filter by game system', async () => {
+      // Age filtering now lives on age groups; game system is a top-level filter.
       const response = await request(app.getHttpServer())
         .get('/api/v1/tournaments')
-        .query({ ageCategory: 'U12' })
+        .query({ gameSystem: '4+1' })
         .expect(200);
 
       expect(response.body.success).toBe(true);
@@ -279,6 +281,13 @@ describe('Tournaments (e2e)', () => {
     });
 
     it('should delete tournament', async () => {
+      // Only draft or cancelled tournaments can be deleted; new ones are
+      // published, so cancel it first (see TournamentsService.remove).
+      await request(app.getHttpServer())
+        .post(`/api/v1/tournaments/${tournamentId}/cancel`)
+        .set('Authorization', `Bearer ${organizerToken}`)
+        .expect(201);
+
       const response = await request(app.getHttpServer())
         .delete(`/api/v1/tournaments/${tournamentId}`)
         .set('Authorization', `Bearer ${organizerToken}`)


### PR DESCRIPTION
## Summary

The **E2E Tests** CI job had been red (26 failures across the `tournaments` and `pot-management` suites) because the tests had drifted from the current API. **No product code is changed — only tests/fixtures.**

### tournaments.e2e + fixture
- Fixture sent a removed `ageCategory` field and ISO-datetime dates; `CreateTournamentDto` forbids unknown props and requires `YYYY-MM-DD`. Removed `ageCategory`, formatted dates date-only.
- Tournaments are created `PUBLISHED` (not `DRAFT`) → fixed the status assertion.
- Only `DRAFT`/`CANCELLED` tournaments can be deleted → the delete test now cancels first.
- `ageCategory` is no longer a top-level query filter (age lives on age groups) → filter test uses a supported field (`gameSystem`).

### pot-management.e2e
- Tournament `level` must be the enum **value** `'I'`, not `'LEVEL_I'`.
- Registrations must be `APPROVED` to be assigned to pots → use `/approve` (not `/approve-without-payment`, which leaves them `PENDING_PAYMENT`).
- Pots are returned dynamically (floor of 1, no fixed 4 pots).
- `potNumber` is bounded 1–32 → invalid-pot test uses `33`.
- Draw takes `numberOfPots: 3` to seed 3 pots of 2 into 2 groups of 3.

## Testing

Ran the full suite locally against Postgres 16:

```
Test Suites: 4 passed, 4 total
Tests:       40 passed, 40 total
```

`pnpm type-check` clean; 0 ESLint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv)_