### PR TITLE
Fix failing unit tests (stale mocks vs current service DI/behavior)

### DIFF
--- a/src/modules/auth/__tests__/cross-device-support.spec.ts
+++ b/src/modules/auth/__tests__/cross-device-support.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from '../auth.service';
+import { MailService } from '../../mail/mail.service';
 import { User } from '../../users/entities/user.entity';
 import { RefreshToken } from '../entities/refresh-token.entity';
 import { UnauthorizedException } from '@nestjs/common';
@@ -90,6 +91,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
           provide: ConfigService,
           useValue: mockConfigService,
         },
+        {
+          provide: MailService,
+          useValue: {
+            sendWelcomeEmail: jest.fn(),
+            sendPasswordResetEmail: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -140,9 +148,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
       const desktopIpAddress = '192.168.1.200';
 
       // CRITICAL: Call refreshTokens with token from mobile, but simulating desktop
-      const result = await service.refreshTokens({
-        refreshToken: mobileRefreshToken,
-      }, desktopIpAddress, desktopDeviceInfo);
+      const result = await service.refreshTokens(
+        {
+          refreshToken: mobileRefreshToken,
+        },
+        desktopIpAddress,
+        desktopDeviceInfo,
+      );
 
       // Verify: Token refresh succeeds (NOT blocked by device change)
       expect(result).toHaveProperty('accessToken');
@@ -183,9 +195,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
       const differentIpAddress = '20.0.0.1';
 
       // This should NOT throw an error because device validation is NOT performed
-      const result = await service.refreshTokens({
-        refreshToken: 'audit-refresh-token',
-      }, differentIpAddress, differentDeviceInfo);
+      const result = await service.refreshTokens(
+        {
+          refreshToken: 'audit-refresh-token',
+        },
+        differentIpAddress,
+        differentDeviceInfo,
+      );
 
       // Verify: Token refresh succeeds despite device/IP change
       expect(result).toBeDefined();
@@ -208,9 +224,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
       // Should throw UnauthorizedException because token is not found
       // (tokens are not found if they're revoked)
       await expect(
-        service.refreshTokens({
-          refreshToken: 'revoked-refresh-token',
-        }, '192.168.1.200', 'Mozilla/5.0 (Windows)'),
+        service.refreshTokens(
+          {
+            refreshToken: 'revoked-refresh-token',
+          },
+          '192.168.1.200',
+          'Mozilla/5.0 (Windows)',
+        ),
       ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -222,9 +242,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
 
       // Invalid token should be rejected
       await expect(
-        service.refreshTokens({
-          refreshToken: 'invalid-token-xyz',
-        }, '192.168.1.100', 'Mozilla/5.0 (iPhone)'),
+        service.refreshTokens(
+          {
+            refreshToken: 'invalid-token-xyz',
+          },
+          '192.168.1.100',
+          'Mozilla/5.0 (iPhone)',
+        ),
       ).rejects.toThrow(UnauthorizedException);
     });
 
@@ -261,9 +285,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
         mockRefreshTokenRepository.create.mockReturnValue({});
         mockRefreshTokenRepository.save.mockResolvedValue({});
 
-        const result = await service.refreshTokens({
-          refreshToken: currentRefreshToken,
-        }, simulation.ip, `Mozilla/5.0 (${simulation.device})`);
+        const result = await service.refreshTokens(
+          {
+            refreshToken: currentRefreshToken,
+          },
+          simulation.ip,
+          `Mozilla/5.0 (${simulation.device})`,
+        );
 
         // All devices should succeed
         expect(result).toHaveProperty('accessToken');
@@ -297,9 +325,13 @@ describe('Cross-Device Token Support (Issue #31)', () => {
       mockRefreshTokenRepository.save.mockResolvedValue({});
 
       // Call with completely different device
-      const result = await service.refreshTokens({
-        refreshToken: 'test-token',
-      }, '9.9.9.9', 'Completely Different Device');
+      const result = await service.refreshTokens(
+        {
+          refreshToken: 'test-token',
+        },
+        '9.9.9.9',
+        'Completely Different Device',
+      );
 
       // If device validation exists, this would fail
       expect(result).toBeDefined();

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
+import { MailService } from '../mail/mail.service';
 import { User } from '../users/entities/user.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
 import { UnauthorizedException, ConflictException } from '@nestjs/common';
@@ -82,6 +83,13 @@ describe('AuthService', () => {
         {
           provide: ConfigService,
           useValue: mockConfigService,
+        },
+        {
+          provide: MailService,
+          useValue: {
+            sendWelcomeEmail: jest.fn(),
+            sendPasswordResetEmail: jest.fn(),
+          },
         },
       ],
     }).compile();

--- a/src/modules/clubs/clubs.service.spec.ts
+++ b/src/modules/clubs/clubs.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ClubsService } from './clubs.service';
+import { FilesService } from '../files/files.service';
 import { Club } from './entities/club.entity';
 import { CreateClubDto, UpdateClubDto } from './dto';
 import {
@@ -48,6 +49,10 @@ describe('ClubsService', () => {
     })),
   };
 
+  const mockFilesService = {
+    upload: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -55,6 +60,10 @@ describe('ClubsService', () => {
         {
           provide: getRepositoryToken(Club),
           useValue: mockRepository,
+        },
+        {
+          provide: FilesService,
+          useValue: mockFilesService,
         },
       ],
     }).compile();

--- a/src/modules/tournaments/tournaments.service.spec.ts
+++ b/src/modules/tournaments/tournaments.service.spec.ts
@@ -53,6 +53,10 @@ describe('TournamentsService', () => {
     addOrderBy: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
+    // Used by syncPastTournamentsAsCompleted()
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected: 0 }),
     getManyAndCount: jest.fn().mockResolvedValue([[mockTournament], 1]),
     getOne: jest.fn().mockResolvedValue(mockTournament),
   });
@@ -65,6 +69,8 @@ describe('TournamentsService', () => {
     update: jest.fn(),
     remove: jest.fn(),
     createQueryBuilder: jest.fn(() => createMockQueryBuilder()),
+    // enrichTournamentData()/list queries use the entity manager for raw SQL
+    manager: { query: jest.fn().mockResolvedValue([]) },
   };
 
   const mockAgeGroupRepository = {
@@ -100,6 +106,12 @@ describe('TournamentsService', () => {
     }).compile();
 
     service = module.get<TournamentsService>(TournamentsService);
+
+    // Default findOne to "no match" so slug generation terminates. Without
+    // this, a prior test's mockResolvedValue(tournament) leaks across tests
+    // (clearAllMocks resets call history, not implementations) and makes
+    // generateUniqueSlug loop forever → OOM. Tests override as needed.
+    mockRepository.findOne.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -287,17 +299,24 @@ describe('TournamentsService', () => {
   });
 
   describe('remove', () => {
+    // Only DRAFT/CANCELLED tournaments can be deleted, and findByIdOrFail
+    // auto-promotes DRAFT → PUBLISHED, so use a CANCELLED tournament here.
+    const cancelledTournament = {
+      ...mockTournament,
+      status: TournamentStatus.CANCELLED,
+    };
+
     it('should remove a tournament when user is owner', async () => {
-      mockRepository.findOne.mockResolvedValue(mockTournament);
-      mockRepository.remove.mockResolvedValue(mockTournament);
+      mockRepository.findOne.mockResolvedValue(cancelledTournament);
+      mockRepository.remove.mockResolvedValue(cancelledTournament);
 
       await service.remove('tournament-1', 'organizer-1', UserRole.ORGANIZER);
 
-      expect(mockRepository.remove).toHaveBeenCalledWith(mockTournament);
+      expect(mockRepository.remove).toHaveBeenCalledWith(cancelledTournament);
     });
 
     it('should throw ForbiddenException when user is not owner', async () => {
-      mockRepository.findOne.mockResolvedValue(mockTournament);
+      mockRepository.findOne.mockResolvedValue(cancelledTournament);
 
       await expect(
         service.remove('tournament-1', 'other-user', UserRole.ORGANIZER),
@@ -305,12 +324,12 @@ describe('TournamentsService', () => {
     });
 
     it('should allow admin to remove any tournament', async () => {
-      mockRepository.findOne.mockResolvedValue(mockTournament);
-      mockRepository.remove.mockResolvedValue(mockTournament);
+      mockRepository.findOne.mockResolvedValue(cancelledTournament);
+      mockRepository.remove.mockResolvedValue(cancelledTournament);
 
       await service.remove('tournament-1', 'admin-user', UserRole.ADMIN);
 
-      expect(mockRepository.remove).toHaveBeenCalledWith(mockTournament);
+      expect(mockRepository.remove).toHaveBeenCalledWith(cancelledTournament);
     });
   });
 
@@ -323,6 +342,7 @@ describe('TournamentsService', () => {
       expect(result).toHaveLength(1);
       expect(mockRepository.find).toHaveBeenCalledWith({
         where: { organizerId: 'organizer-1' },
+        relations: ['ageGroups'],
         order: { startDate: 'DESC' },
       });
     });
@@ -400,14 +420,13 @@ describe('TournamentsService', () => {
 
         await service.create('organizer-1', createDto);
 
-        // Verify age groups repository was called with correct data
-        expect(mockAgeGroupRepository.create).toHaveBeenCalledTimes(2);
-        expect(mockAgeGroupRepository.save).toHaveBeenCalled();
+        // Age groups are persisted with a single save(array) call.
+        expect(mockAgeGroupRepository.save).toHaveBeenCalledTimes(1);
+        const savedAgeGroups = mockAgeGroupRepository.save.mock.calls[0][0];
+        expect(savedAgeGroups).toHaveLength(2);
 
         // Verify first age group contains all required fields
-        const firstAgeGroupCall =
-          mockAgeGroupRepository.create.mock.calls[0][0];
-        expect(firstAgeGroupCall).toMatchObject({
+        expect(savedAgeGroups[0]).toMatchObject({
           birthYear: 2010,
           displayLabel: 'U14',
           gameSystem: '7+1',
@@ -421,9 +440,7 @@ describe('TournamentsService', () => {
         });
 
         // Verify second age group contains all required fields
-        const secondAgeGroupCall =
-          mockAgeGroupRepository.create.mock.calls[1][0];
-        expect(secondAgeGroupCall).toMatchObject({
+        expect(savedAgeGroups[1]).toMatchObject({
           birthYear: 2012,
           displayLabel: 'U12',
           gameSystem: '5+1',
@@ -466,8 +483,11 @@ describe('TournamentsService', () => {
 
         await service.create('organizer-1', createDto);
 
-        expect(mockAgeGroupRepository.create).toHaveBeenCalled();
-        const ageGroupCall = mockAgeGroupRepository.create.mock.calls[0][0];
+        expect(mockAgeGroupRepository.save).toHaveBeenCalled();
+        const savedAgeGroups = mockAgeGroupRepository.save.mock.calls[0][0];
+        const ageGroupCall = Array.isArray(savedAgeGroups)
+          ? savedAgeGroups[0]
+          : savedAgeGroups;
         expect(ageGroupCall.birthYear).toBe(2010);
         expect(ageGroupCall.displayLabel).toBe('U14');
       });
@@ -572,8 +592,9 @@ describe('TournamentsService', () => {
           newAgeGroupData,
         );
 
-        expect(mockAgeGroupRepository.create).toHaveBeenCalled();
-        const createdAgeGroup = mockAgeGroupRepository.create.mock.calls[0][0];
+        // New age groups (no id) are persisted directly via save(entity).
+        expect(mockAgeGroupRepository.save).toHaveBeenCalled();
+        const createdAgeGroup = mockAgeGroupRepository.save.mock.calls[0][0];
         expect(createdAgeGroup).toMatchObject({
           birthYear: 2011,
           minTeams: 4,


### PR DESCRIPTION
## Summary

The **Unit Tests** CI job (4 suites, 38 failures) had been red because the specs drifted from the current services. **No product code changed — only tests.**

- **clubs.service.spec** — `ClubsService` gained a `FilesService` dependency; added a mock provider.
- **auth.service.spec + cross-device-support.spec** — `AuthService` gained a `MailService` dependency; added mock providers to both.
- **tournaments.service.spec** (was crashing the worker with an OOM):
  - **Heap OOM** — a prior test's `findOne.mockResolvedValue(tournament)` leaked across tests (`clearAllMocks` clears call history, not implementations), so `generateUniqueSlug`'s `while` loop spun forever. Default `findOne` to `null` in `beforeEach`; tests override as needed.
  - Mock query builder was missing `update`/`set`/`execute` (used by `syncPastTournamentsAsCompleted`) and the repo mock was missing `manager.query`.
  - `remove()` only deletes `DRAFT`/`CANCELLED`, and `findByIdOrFail` promotes `DRAFT`→`PUBLISHED`, so the remove tests now use a `CANCELLED` tournament.
  - `findByOrganizer` now loads the `ageGroups` relation — updated the assertion.
  - `create()`/`updateAgeGroups` persist age groups via `save()` of plain objects (not `create()`) — updated the age-group assertions.

## Testing

```
Test Suites: 22 passed, 22 total
Tests:       292 passed, 292 total
```

`pnpm type-check` clean; 0 ESLint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv)_