### PR TITLE
Remove global Jest coverage threshold gate

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,14 +24,9 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/(?!.pnpm|uuid)/',
   ],
-  coverageThreshold: {
-    global: {
-      branches: 30,
-      functions: 30,
-      lines: 50,
-      statements: 50,
-    },
-  },
+  // Coverage is still collected and reported to Codecov, but no hard gate is
+  // enforced in CI (the global threshold blocked the job while coverage sits
+  // around ~43%). Reinstate a coverageThreshold here to re-enable the gate.
   setupFilesAfterEnv: ['<rootDir>/../test/setup.ts'],
   testTimeout: 30000,
 };


### PR DESCRIPTION
## Summary

The **Unit Tests** CI job passed on tests (292/292) but failed the job because of the global Jest **coverage threshold** (`lines: 50, statements: 50`) while the codebase sits at ~43% — a gate that blocked the job regardless of test results (it was previously masked by actual test failures).

Per maintainer decision, this removes the hard coverage gate:
- Deletes `coverageThreshold` from `jest.config.js`.
- Coverage is **still collected** (`--coverage`) and **still uploaded to Codecov** — only the pass/fail gate is gone.
- A comment documents how to reinstate the gate later.

## Testing

```
Test Suites: 22 passed, 22 total
Tests:       292 passed, 292 total
```

`pnpm test:cov` now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv)_