### PR TITLE
Run Young Talents Group import automatically on production deploy

### DIFF
--- a/docs/SEEDING.md
+++ b/docs/SEEDING.md
@@ -269,6 +269,23 @@ snapshot) are skipped.
 To refresh the data, replace `src/seeds/data/young-talents-group.json` with a
 new export (same shape) and re-run `pnpm seed:youngtalents`.
 
+### Automatic run on production deploy
+
+Like the Euro-Sportring seed, this import runs automatically on every deploy
+via `scripts/start-prod.sh` — the compiled importer
+(`node dist/seeds/import-young-talents.js --on-deploy`) is launched in the
+**background** before the API starts. Safety properties in deploy mode:
+
+- **Non-blocking**: the API starts immediately; the import runs concurrently
+  and a failure (missing file, DB hiccup) can never fail the deployment
+  (always exits 0).
+- **Single-flight**: a Postgres advisory lock ensures only one replica imports
+  at a time; others skip.
+- **Data ships with the build**: `postbuild` copies
+  `src/seeds/data/*.json` into `dist/seeds/data/`, so the compiled importer
+  finds the snapshot in the production image.
+- **Opt-out**: set `SEED_YOUNGTALENTS_ON_DEPLOY=false` in the environment.
+
 ## Related Documentation
 
 - [Getting Started](./GETTING_STARTED.md)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
+    "postbuild": "node -e \"const fs=require('fs'),p=require('path');const s=p.join('src','seeds','data'),d=p.join('dist','seeds','data');if(fs.existsSync(s)){fs.mkdirSync(d,{recursive:true});for(const f of fs.readdirSync(s)){if(f.endsWith('.json'))fs.copyFileSync(p.join(s,f),p.join(d,f));}}\"",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -1,16 +1,23 @@
 #!/bin/sh
-# Production start-up: launch the Euro-Sportring tournament seed in the
-# background (so the API starts serving immediately), then start the API.
+# Production start-up: launch the tournament data imports in the background (so
+# the API starts serving immediately), then start the API.
 #
-# The seed is idempotent (upserts by url_slug), throttled (1 req/sec), guarded
-# by a Postgres advisory lock (only one replica seeds at a time), and runs in
-# --on-deploy mode so a failed scrape can never break the deployment.
+# Each import is idempotent (upserts by url_slug), guarded by its own Postgres
+# advisory lock (only one replica imports at a time), and runs in --on-deploy
+# mode so a failure can never break the deployment.
 #
-# Opt out by setting SEED_EUROSPORTRING_ON_DEPLOY=false.
+# Opt out individually:
+#   SEED_EUROSPORTRING_ON_DEPLOY=false   # Euro-Sportring (live scrape)
+#   SEED_YOUNGTALENTS_ON_DEPLOY=false    # Young Talents Group (JSON snapshot)
 
 if [ "${SEED_EUROSPORTRING_ON_DEPLOY:-true}" != "false" ]; then
   echo "[start-prod] Starting Euro-Sportring seed in background (set SEED_EUROSPORTRING_ON_DEPLOY=false to disable)"
   node dist/seeds/scrape-euro-sportring.js --on-deploy &
+fi
+
+if [ "${SEED_YOUNGTALENTS_ON_DEPLOY:-true}" != "false" ]; then
+  echo "[start-prod] Starting Young Talents Group import in background (set SEED_YOUNGTALENTS_ON_DEPLOY=false to disable)"
+  node dist/seeds/import-young-talents.js --on-deploy &
 fi
 
 exec node dist/main

--- a/src/seeds/import-young-talents.ts
+++ b/src/seeds/import-young-talents.ts
@@ -20,7 +20,7 @@
  *   pnpm seed:youngtalents -- --file=path.json # override input file
  */
 import 'reflect-metadata';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, QueryRunner, Repository } from 'typeorm';
 import { join } from 'path';
 import { readFileSync, existsSync } from 'fs';
 import { randomUUID } from 'crypto';
@@ -81,7 +81,14 @@ interface CliOptions {
   dryRun: boolean;
   limit?: number;
   file: string;
+  // Deploy mode: never exit non-zero (a failed import must not fail the
+  // deploy) and serialize concurrent replicas via a Postgres advisory lock.
+  onDeploy: boolean;
 }
+
+// Advisory-lock key identifying "the Young Talents import" so only one replica
+// imports at a time. Distinct from the Euro-Sportring key (727270001).
+const ADVISORY_LOCK_KEY = 727270002;
 
 // ── Local helpers (avoid seeds/utils/helpers → faker devDependency) ──
 
@@ -321,9 +328,14 @@ async function importTournament(
 // ── Entry point ───────────────────────────────────────────
 
 function parseCli(argv: string[]): CliOptions {
-  const options: CliOptions = { dryRun: false, file: defaultFile() };
+  const options: CliOptions = {
+    dryRun: false,
+    file: defaultFile(),
+    onDeploy: false,
+  };
   for (const arg of argv) {
     if (arg === '--dry-run') options.dryRun = true;
+    else if (arg === '--on-deploy') options.onDeploy = true;
     else if (arg.startsWith('--limit='))
       options.limit = parseInt(arg.slice(8), 10);
     else if (arg.startsWith('--file=')) options.file = arg.slice(7);
@@ -333,13 +345,11 @@ function parseCli(argv: string[]): CliOptions {
 
 function loadSource(file: string): SourceTournament[] {
   if (!existsSync(file)) {
-    console.error(`❌ Input file not found: ${file}`);
-    process.exit(1);
+    throw new Error(`Input file not found: ${file}`);
   }
   const parsed = JSON.parse(readFileSync(file, 'utf8')) as unknown;
   if (!Array.isArray(parsed)) {
-    console.error('❌ Input file must be a JSON array of tournaments.');
-    process.exit(1);
+    throw new Error('Input file must be a JSON array of tournaments.');
   }
   return parsed as SourceTournament[];
 }
@@ -347,10 +357,9 @@ function loadSource(file: string): SourceTournament[] {
 async function connect(): Promise<DataSource> {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
-    console.error(
-      '❌ DATABASE_URL environment variable is required (or use --dry-run).',
+    throw new Error(
+      'DATABASE_URL environment variable is required (or use --dry-run).',
     );
-    process.exit(1);
   }
   const sslMode = new URL(databaseUrl).searchParams.get('sslmode');
   const dataSource = new DataSource({
@@ -368,11 +377,11 @@ async function connect(): Promise<DataSource> {
   return dataSource;
 }
 
-async function main(): Promise<void> {
-  const options = parseCli(process.argv.slice(2));
-
+async function main(options: CliOptions): Promise<void> {
   console.log('🌍 Importing Young Talents Group tournaments');
-  console.log(`   file: ${options.file}${options.dryRun ? ' | DRY RUN' : ''}`);
+  console.log(
+    `   file: ${options.file}${options.dryRun ? ' | DRY RUN' : ''}${options.onDeploy ? ' | deploy mode' : ''}`,
+  );
 
   let source = loadSource(options.file);
   if (options.limit) source = source.slice(0, options.limit);
@@ -409,6 +418,23 @@ async function main(): Promise<void> {
   }
 
   const dataSource = await connect();
+
+  // Serialize concurrent replicas: only one instance imports at a time.
+  const lockRunner: QueryRunner = dataSource.createQueryRunner();
+  await lockRunner.connect();
+  const [{ locked }] = (await lockRunner.query(
+    'SELECT pg_try_advisory_lock($1) AS locked',
+    [ADVISORY_LOCK_KEY],
+  )) as [{ locked: boolean }];
+  if (!locked) {
+    console.log(
+      '🔒 Another instance is already running the Young Talents import — skipping.',
+    );
+    await lockRunner.release();
+    await dataSource.destroy();
+    return;
+  }
+
   try {
     const organizerId = await ensureOrganizer(dataSource);
     let inserted = 0;
@@ -437,11 +463,17 @@ async function main(): Promise<void> {
     );
     console.log(`   Organizer: ${ORGANIZER_EMAIL}`);
   } finally {
+    await lockRunner.query('SELECT pg_advisory_unlock($1)', [
+      ADVISORY_LOCK_KEY,
+    ]);
+    await lockRunner.release();
     await dataSource.destroy();
   }
 }
 
-main().catch((error) => {
+const cliOptions = parseCli(process.argv.slice(2));
+main(cliOptions).catch((error) => {
   console.error('❌ Import failed:', error);
-  process.exit(1);
+  // In deploy mode a failed import must never fail the deployment/start-up.
+  process.exit(cliOptions.onDeploy ? 0 : 1);
 });


### PR DESCRIPTION
## Summary

Makes the Young Talents Group import run automatically on every production deploy, mirroring the Euro-Sportring seed.

- `scripts/start-prod.sh` now launches `node dist/seeds/import-young-talents.js --on-deploy` **in the background** before starting the API (in addition to the Euro-Sportring seed). Opt out with `SEED_YOUNGTALENTS_ON_DEPLOY=false`.
- **Deploy-mode hardening** of the importer:
  - `--on-deploy` flag: always exits 0, so a failed import (missing file, DB hiccup) can never fail the deployment.
  - Postgres **advisory lock** (key `727270002`, distinct from Euro-Sportring's) so concurrent replicas skip instead of double-importing.
  - `loadSource`/`connect` now throw instead of `process.exit`, so failures are caught and handled by deploy mode.
- **Data ships with the build**: a `postbuild` step copies `src/seeds/data/*.json` → `dist/seeds/data/`, so the compiled importer finds the snapshot in the production image (tsc doesn't copy `.json`).

## Testing

Against a local Postgres 16, using the **compiled** `dist` artifacts:

- Two concurrent `--on-deploy` instances: one imported, the other took the lock path and skipped/updated — no double-import.
- `postbuild` confirmed to copy the 720 KB JSON into `dist/seeds/data/`.
- Exit codes: `--on-deploy` with a bad DB → **0**; with a missing file → **0**; normal mode with a bad DB → **1**.

`pnpm type-check` clean; 0 ESLint errors. Documented in `docs/SEEDING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv)_