### PR TITLE
Add leads CRM in the admin module

### DIFF
--- a/docs/LEADS.md
+++ b/docs/LEADS.md
@@ -1,0 +1,49 @@
+# Leads CRM (admin)
+
+A lightweight CRM for tracking tournament organisers as sales/outreach leads.
+All endpoints live under `/api/v1/admin/leads` and require an **ADMIN** JWT
+(`JwtAuthGuard` + `RolesGuard`).
+
+## Data model (`leads` table)
+
+| Field | Notes |
+|-------|-------|
+| `tournamentId` | Optional link to a tournament. Unique when set (one lead per tournament); manual leads have `null`. |
+| `tournamentName`, `startDate`, `location`, `sourceUrl`, `organiser` | Denormalized tournament details (kept even if the tournament is deleted). |
+| `contactName`, `contactEmail`, `contactPhone` | Filled in by the sales team. |
+| `status` | Pipeline stage: `NEW → CONTACTED → QUALIFIED → WON / LOST` (default `NEW`). |
+| `notes` | Free text. |
+| `assignedToId` | Optional user the lead is assigned to. |
+| `source` | Origin: `young-talents-group`, `euro-sportring`, `platform`, or `manual`. |
+
+## Endpoints
+
+| Method & path | Purpose |
+|---------------|---------|
+| `GET /admin/leads` | List with pagination + filters: `status`, `source`, `assignedToId`, `search` (matches tournament name, organiser, contact name/email). |
+| `GET /admin/leads/stats` | Total + count per pipeline stage (CRM dashboard). |
+| `GET /admin/leads/export` | Download the **filtered** leads as CSV (same query params as the list). Excel-friendly (UTF-8 BOM, RFC-4180 quoting). |
+| `POST /admin/leads/import` | Create a lead for every tournament that doesn't have one yet. **Idempotent** — existing leads keep their CRM state. |
+| `GET /admin/leads/:id` | Get one lead (with `assignedTo` and `tournament`). |
+| `POST /admin/leads` | Create a lead manually. |
+| `PATCH /admin/leads/:id` | Update status, notes, contact details, or assignee. |
+| `DELETE /admin/leads/:id` | Delete a lead. |
+
+## Populating from tournaments
+
+Call `POST /admin/leads/import` once to seed a lead per tournament (Young
+Talents + Euro-Sportring + anything else in the DB). It pulls the tournament
+name, start date, location, and the source URL (parsed from the tournament
+description the importers embed as `Source: <url>`). Contact email/phone are
+left blank for the sales team to fill in.
+
+Because the import is idempotent, you can re-run it after new tournaments are
+imported (e.g. after a deploy) to pick up the new ones without disturbing
+leads you've already worked.
+
+## CSV export
+
+`GET /admin/leads/export` returns the columns: Tournament Name, Start Date,
+Status, Organiser, Contact Name, Contact Email, Contact Phone, Location,
+Source URL, Assigned To, Notes, Source — respecting any filter query params.
+This covers pasting into a leads form / mail-merge.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -25,6 +25,7 @@ import { TeamsModule } from './modules/teams/teams.module';
 import { PlayersModule } from './modules/players/players.module';
 import { DashboardModule } from './modules/dashboard/dashboard.module';
 import { SitemapModule } from './modules/sitemap/sitemap.module';
+import { LeadsModule } from './modules/leads/leads.module';
 
 @Module({
   imports: [
@@ -74,6 +75,7 @@ import { SitemapModule } from './modules/sitemap/sitemap.module';
     PlayersModule,
     DashboardModule,
     SitemapModule,
+    LeadsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/common/enums/index.ts
+++ b/src/common/enums/index.ts
@@ -13,6 +13,15 @@ export enum TournamentStatus {
   CANCELLED = 'CANCELLED',
 }
 
+/** CRM pipeline stage for a sales/outreach lead. */
+export enum LeadStatus {
+  NEW = 'NEW',
+  CONTACTED = 'CONTACTED',
+  QUALIFIED = 'QUALIFIED',
+  WON = 'WON',
+  LOST = 'LOST',
+}
+
 export enum TournamentLevel {
   LEVEL_I = 'I',
   LEVEL_II = 'II',

--- a/src/modules/leads/dto/create-lead.dto.ts
+++ b/src/modules/leads/dto/create-lead.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsString,
+  IsOptional,
+  IsEmail,
+  IsEnum,
+  IsUUID,
+  Matches,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LeadStatus } from '../../../common/enums';
+
+export class CreateLeadDto {
+  @ApiProperty({ example: 'Barcelona Easter Cup' })
+  @IsString()
+  @MaxLength(255)
+  tournamentName: string;
+
+  @ApiPropertyOptional({ example: '2027-04-02', description: 'YYYY-MM-DD' })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'startDate must be YYYY-MM-DD' })
+  startDate?: string;
+
+  @ApiPropertyOptional({ example: 'Barcelona, Spain' })
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @ApiPropertyOptional({ example: 'https://example.com/tournament' })
+  @IsOptional()
+  @IsString()
+  sourceUrl?: string;
+
+  @ApiPropertyOptional({ example: 'FC Barcelona Youth' })
+  @IsOptional()
+  @IsString()
+  organiser?: string;
+
+  @ApiPropertyOptional({ example: 'Jordi Puig' })
+  @IsOptional()
+  @IsString()
+  contactName?: string;
+
+  @ApiPropertyOptional({ example: 'organiser@example.com' })
+  @IsOptional()
+  @IsEmail()
+  contactEmail?: string;
+
+  @ApiPropertyOptional({ example: '+34 600 000 000' })
+  @IsOptional()
+  @IsString()
+  contactPhone?: string;
+
+  @ApiPropertyOptional({ enum: LeadStatus, default: LeadStatus.NEW })
+  @IsOptional()
+  @IsEnum(LeadStatus)
+  status?: LeadStatus;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @ApiPropertyOptional({ description: 'User id to assign this lead to' })
+  @IsOptional()
+  @IsUUID()
+  assignedToId?: string;
+
+  @ApiPropertyOptional({ description: 'Link to an existing tournament' })
+  @IsOptional()
+  @IsUUID()
+  tournamentId?: string;
+}

--- a/src/modules/leads/dto/index.ts
+++ b/src/modules/leads/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './create-lead.dto';
+export * from './update-lead.dto';
+export * from './lead-filter.dto';

--- a/src/modules/leads/dto/lead-filter.dto.ts
+++ b/src/modules/leads/dto/lead-filter.dto.ts
@@ -1,0 +1,28 @@
+import { IsOptional, IsEnum, IsString, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../../common/dto/pagination.dto';
+import { LeadStatus } from '../../../common/enums';
+
+export class LeadFilterDto extends PaginationDto {
+  @ApiPropertyOptional({ enum: LeadStatus })
+  @IsOptional()
+  @IsEnum(LeadStatus)
+  status?: LeadStatus;
+
+  @ApiPropertyOptional({
+    description: 'Search tournament name, organiser, contact name/email',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by assigned user id' })
+  @IsOptional()
+  @IsUUID()
+  assignedToId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by origin source' })
+  @IsOptional()
+  @IsString()
+  source?: string;
+}

--- a/src/modules/leads/dto/update-lead.dto.ts
+++ b/src/modules/leads/dto/update-lead.dto.ts
@@ -1,0 +1,8 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateLeadDto } from './create-lead.dto';
+
+/**
+ * All lead fields are optional on update (status change, adding notes /
+ * contact details, reassigning, etc.).
+ */
+export class UpdateLeadDto extends PartialType(CreateLeadDto) {}

--- a/src/modules/leads/entities/lead.entity.ts
+++ b/src/modules/leads/entities/lead.entity.ts
@@ -1,0 +1,90 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { LeadStatus } from '../../../common/enums';
+import { User } from '../../users/entities/user.entity';
+import { Tournament } from '../../tournaments/entities/tournament.entity';
+
+/**
+ * A sales/outreach lead tracked in the admin CRM. Usually derived from a
+ * tournament (one lead per tournament), but can also be created manually.
+ */
+@Entity('leads')
+// One lead per tournament; manual leads (null tournament_id) are unconstrained.
+@Index('IDX_leads_tournament_unique', ['tournamentId'], {
+  unique: true,
+  where: '"tournament_id" IS NOT NULL',
+})
+export class Lead {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // ── Link back to the originating tournament (optional) ──
+  @Column({ name: 'tournament_id', type: 'uuid', nullable: true })
+  tournamentId: string | null;
+
+  @ManyToOne(() => Tournament, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'tournament_id' })
+  tournament: Tournament | null;
+
+  // ── Denormalized tournament details (kept even if the tournament is gone) ──
+  @Index()
+  @Column({ name: 'tournament_name' })
+  tournamentName: string;
+
+  @Column({ name: 'start_date', type: 'date', nullable: true })
+  startDate: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  location: string | null;
+
+  @Column({ name: 'source_url', type: 'text', nullable: true })
+  sourceUrl: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  organiser: string | null;
+
+  // ── Contact details (filled in by the sales team) ──
+  @Column({ name: 'contact_name', type: 'varchar', nullable: true })
+  contactName: string | null;
+
+  @Index()
+  @Column({ name: 'contact_email', type: 'varchar', nullable: true })
+  contactEmail: string | null;
+
+  @Column({ name: 'contact_phone', type: 'varchar', nullable: true })
+  contactPhone: string | null;
+
+  // ── CRM tracking ──
+  @Index()
+  @Column({ type: 'enum', enum: LeadStatus, default: LeadStatus.NEW })
+  status: LeadStatus;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @Column({ name: 'assigned_to_id', type: 'uuid', nullable: true })
+  assignedToId: string | null;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'assigned_to_id' })
+  assignedTo: User | null;
+
+  // Origin: 'young-talents-group' | 'euro-sportring' | 'platform' | 'manual'
+  @Index()
+  @Column({ type: 'varchar', nullable: true })
+  source: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/src/modules/leads/leads.controller.ts
+++ b/src/modules/leads/leads.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  Query,
+  Res,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import type { Response } from 'express';
+import { LeadsService } from './leads.service';
+import { CreateLeadDto, UpdateLeadDto, LeadFilterDto } from './dto';
+import { JwtAuthGuard, RolesGuard } from '../auth/guards';
+import { Roles } from '../../common/decorators';
+import { UserRole } from '../../common/enums';
+
+@ApiTags('Admin')
+@Controller('admin/leads')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+@ApiBearerAuth()
+export class LeadsController {
+  constructor(private readonly leadsService: LeadsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List leads (filter + paginate)' })
+  @ApiResponse({ status: 200, description: 'Paginated list of leads' })
+  findAll(@Query() filter: LeadFilterDto) {
+    return this.leadsService.findAll(filter);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Lead counts per pipeline stage' })
+  getStats() {
+    return this.leadsService.getStats();
+  }
+
+  @Get('export')
+  @ApiOperation({ summary: 'Export the (filtered) leads as CSV' })
+  async exportCsv(
+    @Query() filter: LeadFilterDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    const csv = await this.leadsService.exportCsv(filter);
+    res
+      .type('text/csv; charset=utf-8')
+      .set('Content-Disposition', 'attachment; filename="leads.csv"')
+      // Prepend a BOM so Excel opens UTF-8 correctly.
+      .send('﻿' + csv);
+  }
+
+  @Post('import')
+  @ApiOperation({
+    summary: 'Create a lead for every tournament without one (idempotent)',
+  })
+  importFromTournaments() {
+    return this.leadsService.importFromTournaments();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a lead' })
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.leadsService.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a lead manually' })
+  create(@Body() dto: CreateLeadDto) {
+    return this.leadsService.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a lead (status, notes, contact, assignee)' })
+  update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateLeadDto) {
+    return this.leadsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a lead' })
+  remove(@Param('id', ParseUUIDPipe) id: string) {
+    return this.leadsService.remove(id);
+  }
+}

--- a/src/modules/leads/leads.module.ts
+++ b/src/modules/leads/leads.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LeadsService } from './leads.service';
+import { LeadsController } from './leads.controller';
+import { Lead } from './entities/lead.entity';
+import { Tournament } from '../tournaments/entities/tournament.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Lead, Tournament])],
+  controllers: [LeadsController],
+  providers: [LeadsService],
+  exports: [LeadsService],
+})
+export class LeadsModule {}

--- a/src/modules/leads/leads.service.spec.ts
+++ b/src/modules/leads/leads.service.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { LeadsService } from './leads.service';
+import { Lead } from './entities/lead.entity';
+import { Tournament } from '../tournaments/entities/tournament.entity';
+import { LeadStatus } from '../../common/enums';
+
+const createQb = (rows: Partial<Lead>[], total = rows.length) => ({
+  leftJoinAndSelect: jest.fn().mockReturnThis(),
+  andWhere: jest.fn().mockReturnThis(),
+  orderBy: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  take: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  addSelect: jest.fn().mockReturnThis(),
+  groupBy: jest.fn().mockReturnThis(),
+  getCount: jest.fn().mockResolvedValue(total),
+  getMany: jest.fn().mockResolvedValue(rows),
+  getRawMany: jest.fn().mockResolvedValue([
+    { status: LeadStatus.NEW, count: '2' },
+    { status: LeadStatus.WON, count: '1' },
+  ]),
+});
+
+describe('LeadsService', () => {
+  let service: LeadsService;
+  let qb: ReturnType<typeof createQb>;
+
+  const lead: Partial<Lead> = {
+    id: 'lead-1',
+    tournamentName: 'Barcelona Cup',
+    startDate: '2027-04-02',
+    status: LeadStatus.NEW,
+    location: 'Barcelona, Spain',
+    sourceUrl: 'https://x/y',
+    contactEmail: 'a@b.com',
+    contactPhone: null,
+    organiser: null,
+    contactName: null,
+    notes: null,
+    assignedTo: null,
+    source: 'young-talents-group',
+  };
+
+  const leadsRepo = {
+    create: jest.fn((v) => v),
+    save: jest.fn((v) => Promise.resolve(v)),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(() => qb),
+  };
+  const tournamentsRepo = {
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    qb = createQb([lead]);
+    leadsRepo.createQueryBuilder.mockReturnValue(qb);
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LeadsService,
+        { provide: getRepositoryToken(Lead), useValue: leadsRepo },
+        { provide: getRepositoryToken(Tournament), useValue: tournamentsRepo },
+      ],
+    }).compile();
+    service = module.get(LeadsService);
+    jest.clearAllMocks();
+    leadsRepo.createQueryBuilder.mockReturnValue(qb);
+    leadsRepo.create.mockImplementation((v) => v);
+    leadsRepo.save.mockImplementation((v) => Promise.resolve(v));
+  });
+
+  it('creates a manual lead defaulting to NEW/manual source', async () => {
+    await service.create({ tournamentName: 'X' });
+    expect(leadsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ status: LeadStatus.NEW, source: 'manual' }),
+    );
+  });
+
+  it('tags a lead linked to a tournament as source=platform', async () => {
+    await service.create({ tournamentName: 'X', tournamentId: 't-1' });
+    expect(leadsRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'platform' }),
+    );
+  });
+
+  it('lists with pagination meta', async () => {
+    const res = await service.findAll({ page: 2, pageSize: 5 });
+    expect(qb.skip).toHaveBeenCalledWith(5);
+    expect(qb.take).toHaveBeenCalledWith(5);
+    expect(res.meta).toEqual({ total: 1, page: 2, limit: 5, totalPages: 1 });
+  });
+
+  it('applies status/search filters', async () => {
+    await service.findAll({ status: LeadStatus.CONTACTED, search: 'cup' });
+    expect(qb.andWhere).toHaveBeenCalledWith('lead.status = :status', {
+      status: LeadStatus.CONTACTED,
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('ILIKE'), {
+      q: '%cup%',
+    });
+  });
+
+  it('throws NotFound for a missing lead', async () => {
+    leadsRepo.findOne.mockResolvedValue(null);
+    await expect(service.findOne('nope')).rejects.toThrow(NotFoundException);
+  });
+
+  it('aggregates stats per status with zero-filled stages', async () => {
+    const stats = await service.getStats();
+    expect(stats.total).toBe(3);
+    expect(stats.byStatus[LeadStatus.NEW]).toBe(2);
+    expect(stats.byStatus[LeadStatus.WON]).toBe(1);
+    expect(stats.byStatus[LeadStatus.LOST]).toBe(0);
+  });
+
+  it('imports one lead per not-yet-seeded tournament (idempotent)', async () => {
+    tournamentsRepo.find.mockResolvedValue([
+      {
+        id: 't-1',
+        name: 'A',
+        startDate: '2027-01-01',
+        location: 'L',
+        description: 'Source: https://src/a',
+        urlSlug: 'euro-sportring-a',
+      },
+      { id: 't-2', name: 'B', urlSlug: 'young-talents-group-b' },
+    ]);
+    // t-2 already has a lead
+    leadsRepo.find.mockResolvedValue([{ tournamentId: 't-2' }]);
+
+    const res = await service.importFromTournaments();
+    expect(res).toEqual({ created: 1, skipped: 1 });
+    expect(leadsRepo.save).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          tournamentId: 't-1',
+          sourceUrl: 'https://src/a',
+          source: 'euro-sportring',
+          status: LeadStatus.NEW,
+        }),
+      ],
+      { chunk: 500 },
+    );
+  });
+
+  it('exports CSV with a header row and RFC-4180 quoting', async () => {
+    qb.getMany.mockResolvedValue([
+      { ...lead, location: 'Pitești, Romania', notes: 'a, b' },
+    ]);
+    const csv = await service.exportCsv({});
+    const [header, row] = csv.split('\r\n');
+    expect(header).toBe(
+      'Tournament Name,Start Date,Status,Organiser,Contact Name,Contact Email,Contact Phone,Location,Source URL,Assigned To,Notes,Source',
+    );
+    expect(row).toContain('"Pitești, Romania"');
+    expect(row).toContain('"a, b"');
+  });
+});

--- a/src/modules/leads/leads.service.ts
+++ b/src/modules/leads/leads.service.ts
@@ -1,0 +1,229 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Lead } from './entities/lead.entity';
+import { Tournament } from '../tournaments/entities/tournament.entity';
+import { CreateLeadDto, UpdateLeadDto, LeadFilterDto } from './dto';
+import { LeadStatus } from '../../common/enums';
+import { PaginatedResponse } from '../../common/interfaces';
+
+@Injectable()
+export class LeadsService {
+  constructor(
+    @InjectRepository(Lead)
+    private readonly leadsRepository: Repository<Lead>,
+    @InjectRepository(Tournament)
+    private readonly tournamentsRepository: Repository<Tournament>,
+  ) {}
+
+  async create(dto: CreateLeadDto): Promise<Lead> {
+    const lead = this.leadsRepository.create({
+      ...dto,
+      status: dto.status ?? LeadStatus.NEW,
+      source: dto.tournamentId ? 'platform' : 'manual',
+    });
+    return this.leadsRepository.save(lead);
+  }
+
+  async findAll(filter: LeadFilterDto): Promise<PaginatedResponse<Lead>> {
+    const page = filter.page ?? 1;
+    const limit = filter.pageSize ?? 20;
+
+    const qb = this.leadsRepository
+      .createQueryBuilder('lead')
+      .leftJoinAndSelect('lead.assignedTo', 'assignedTo');
+
+    if (filter.status) {
+      qb.andWhere('lead.status = :status', { status: filter.status });
+    }
+    if (filter.assignedToId) {
+      qb.andWhere('lead.assignedToId = :assignedToId', {
+        assignedToId: filter.assignedToId,
+      });
+    }
+    if (filter.source) {
+      qb.andWhere('lead.source = :source', { source: filter.source });
+    }
+    if (filter.search) {
+      qb.andWhere(
+        `(lead.tournamentName ILIKE :q OR lead.organiser ILIKE :q OR lead.contactName ILIKE :q OR lead.contactEmail ILIKE :q)`,
+        { q: `%${filter.search}%` },
+      );
+    }
+
+    const total = await qb.getCount();
+    const data = await qb
+      .orderBy('lead.createdAt', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getMany();
+
+    return {
+      data,
+      meta: { total, page, limit, totalPages: Math.ceil(total / limit) },
+    };
+  }
+
+  async findOne(id: string): Promise<Lead> {
+    const lead = await this.leadsRepository.findOne({
+      where: { id },
+      relations: ['assignedTo', 'tournament'],
+    });
+    if (!lead) throw new NotFoundException(`Lead ${id} not found`);
+    return lead;
+  }
+
+  async update(id: string, dto: UpdateLeadDto): Promise<Lead> {
+    const lead = await this.findOne(id);
+    Object.assign(lead, dto);
+    return this.leadsRepository.save(lead);
+  }
+
+  async remove(id: string): Promise<void> {
+    const lead = await this.findOne(id);
+    await this.leadsRepository.remove(lead);
+  }
+
+  /** Counts per pipeline stage plus the total — for the CRM dashboard. */
+  async getStats(): Promise<{
+    total: number;
+    byStatus: Record<LeadStatus, number>;
+  }> {
+    const rows = await this.leadsRepository
+      .createQueryBuilder('lead')
+      .select('lead.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('lead.status')
+      .getRawMany<{ status: LeadStatus; count: string }>();
+
+    const byStatus = Object.values(LeadStatus).reduce(
+      (acc, s) => ({ ...acc, [s]: 0 }),
+      {} as Record<LeadStatus, number>,
+    );
+    let total = 0;
+    for (const row of rows) {
+      const n = parseInt(row.count, 10);
+      byStatus[row.status] = n;
+      total += n;
+    }
+    return { total, byStatus };
+  }
+
+  /**
+   * Create one lead per tournament that does not already have one. Idempotent:
+   * existing leads are left untouched (their CRM state is preserved).
+   */
+  async importFromTournaments(): Promise<{
+    created: number;
+    skipped: number;
+  }> {
+    const tournaments = await this.tournamentsRepository.find({
+      select: ['id', 'name', 'startDate', 'location', 'description', 'urlSlug'],
+    });
+
+    const existing = await this.leadsRepository.find({
+      select: ['tournamentId'],
+      where: {},
+    });
+    const seeded = new Set(
+      existing.map((l) => l.tournamentId).filter(Boolean) as string[],
+    );
+
+    let skipped = 0;
+    const toInsert: Lead[] = [];
+
+    for (const t of tournaments) {
+      if (seeded.has(t.id)) {
+        skipped++;
+        continue;
+      }
+      toInsert.push(
+        this.leadsRepository.create({
+          tournamentId: t.id,
+          tournamentName: t.name,
+          startDate: t.startDate
+            ? typeof t.startDate === 'string'
+              ? t.startDate
+              : new Date(t.startDate).toISOString().slice(0, 10)
+            : null,
+          location: t.location ?? null,
+          sourceUrl: extractSourceUrl(t.description),
+          status: LeadStatus.NEW,
+          source: sourceFromSlug(t.urlSlug),
+        }),
+      );
+    }
+
+    if (toInsert.length > 0) {
+      // chunk keeps the parameter count sane on large imports.
+      await this.leadsRepository.save(toInsert, { chunk: 500 });
+    }
+
+    return { created: toInsert.length, skipped };
+  }
+
+  /** Export the filtered leads as a CSV string (for a leads form / mail merge). */
+  async exportCsv(filter: LeadFilterDto): Promise<string> {
+    // Export ignores pagination — return every matching row.
+    const { data } = await this.findAll({
+      ...filter,
+      page: 1,
+      pageSize: 100000,
+    });
+
+    const headers = [
+      'Tournament Name',
+      'Start Date',
+      'Status',
+      'Organiser',
+      'Contact Name',
+      'Contact Email',
+      'Contact Phone',
+      'Location',
+      'Source URL',
+      'Assigned To',
+      'Notes',
+      'Source',
+    ];
+
+    const rows = data.map((l) => [
+      l.tournamentName,
+      l.startDate ?? '',
+      l.status,
+      l.organiser ?? '',
+      l.contactName ?? '',
+      l.contactEmail ?? '',
+      l.contactPhone ?? '',
+      l.location ?? '',
+      l.sourceUrl ?? '',
+      l.assignedTo
+        ? `${l.assignedTo.firstName ?? ''} ${l.assignedTo.lastName ?? ''}`.trim()
+        : '',
+      l.notes ?? '',
+      l.source ?? '',
+    ]);
+
+    return [headers, ...rows].map((r) => r.map(csvCell).join(',')).join('\r\n');
+  }
+}
+
+/** RFC-4180 CSV escaping: quote when the value contains ", comma, or newline. */
+function csvCell(value: string): string {
+  const s = String(value ?? '');
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Pull the "Source: <url>" line the importers embed in the description. */
+function extractSourceUrl(description?: string | null): string | null {
+  if (!description) return null;
+  const match = /Source:\s*(\S+)/i.exec(description);
+  return match ? match[1] : null;
+}
+
+function sourceFromSlug(urlSlug?: string | null): string {
+  if (!urlSlug) return 'platform';
+  if (urlSlug.startsWith('young-talents-group-')) return 'young-talents-group';
+  if (urlSlug.startsWith('euro-sportring-')) return 'euro-sportring';
+  return 'platform';
+}


### PR DESCRIPTION
## Summary

Adds a lightweight **leads CRM in the admin module** so the team can track tournament organisers as sales leads. All endpoints are under `/api/v1/admin/leads` and require an **ADMIN** JWT.

- **`Lead` entity** (`leads` table): denormalized tournament details (name, start date, location, source URL, organiser) + contact fields (name/email/phone) + pipeline `status` (`NEW → CONTACTED → QUALIFIED → WON / LOST`) + notes + assignee + origin `source`. One lead per tournament (partial unique index on `tournament_id`); manual leads (`null`) are unconstrained.
- **Endpoints**:
  - `GET /admin/leads` — list, filter by `status` / `source` / `assignedToId` / `search`, paginated
  - `GET /admin/leads/stats` — total + count per pipeline stage
  - `GET /admin/leads/export` — CSV of the filtered leads (Excel-friendly: UTF-8 BOM, RFC-4180 quoting) — covers the original "spreadsheet for a leads form" ask on demand
  - `POST /admin/leads/import` — one lead per tournament without one, **idempotent** (existing leads keep their CRM state)
  - `GET/POST/PATCH/DELETE /admin/leads[/:id]` — standard CRUD
- Import pulls name / date / location and the source URL parsed from the `Source: <url>` line the tournament importers embed in the description; contact email/phone are left blank for the sales team to fill.

## Testing

End-to-end against Postgres 16 (as an admin): imported 30 leads from tournaments, verified stats, status filter, search, status/contact update, manual create, CSV export (correct content-type + quoting), delete, idempotent re-import (0 created / 30 skipped), and that unauthenticated requests get 401.

8 unit tests for the service. Full unit suite: **300/300 pass**. `pnpm type-check` clean (my code); 0 ESLint errors. Documented in `docs/LEADS.md`.

## Note

Populate the CRM by calling `POST /admin/leads/import` once (re-run after new tournaments arrive — it's idempotent). I kept this admin-triggered rather than auto-running on deploy to avoid a race with the background tournament seeds; happy to wire it into the deploy flow if you'd prefer it fully automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv

---
_Generated by [Claude Code](https://claude.ai/code/session_0183WNG6vSDa4SQB4C6hd3Zv)_